### PR TITLE
Consume NIC dump

### DIFF
--- a/api/src/main/java/org/motechproject/nms/api/web/AddFlwRequest.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/AddFlwRequest.java
@@ -1,0 +1,111 @@
+package org.motechproject.nms.api.web;
+
+/**
+ * Request body for creating or updating an flw
+ * This is used primarily as an ops task to add/update flw properties from broken MCTS sync
+ */
+public class AddFlwRequest {
+    private String name;
+    private String mctsFlwId;
+    private Long contactNumber;
+    private Integer stateId;
+    private Integer districtId;
+    private String talukaId;
+    private Integer phcId;
+    private Integer subcentreId;
+    private Integer villageId;
+    private Integer healthblockId;
+    private String type;
+
+    public AddFlwRequest() {
+
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getMctsFlwId() {
+        return mctsFlwId;
+    }
+
+    public void setMctsFlwId(String mctsFlwId) {
+        this.mctsFlwId = mctsFlwId;
+    }
+
+    public Long getContactNumber() {
+        return contactNumber;
+    }
+
+    public void setContactNumber(Long contactNumber) {
+        this.contactNumber = contactNumber;
+    }
+
+    public Integer getStateId() {
+        return stateId;
+    }
+
+    public void setStateId(Integer stateId) {
+        this.stateId = stateId;
+    }
+
+    public Integer getDistrictId() {
+        return districtId;
+    }
+
+    public void setDistrictId(Integer districtId) {
+        this.districtId = districtId;
+    }
+
+    public String getTalukaId() {
+        return talukaId;
+    }
+
+    public void setTalukaId(String talukaId) {
+        this.talukaId = talukaId;
+    }
+
+    public Integer getPhcId() {
+        return phcId;
+    }
+
+    public void setPhcId(Integer phcId) {
+        this.phcId = phcId;
+    }
+
+    public Integer getSubcentreId() {
+        return subcentreId;
+    }
+
+    public void setSubcentreId(Integer subcentreId) {
+        this.subcentreId = subcentreId;
+    }
+
+    public Integer getVillageId() {
+        return villageId;
+    }
+
+    public void setVillageId(Integer villageId) {
+        this.villageId = villageId;
+    }
+
+    public Integer getHealthblockId() {
+        return healthblockId;
+    }
+
+    public void setHealthblockId(Integer healthblockId) {
+        this.healthblockId = healthblockId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
@@ -2,6 +2,8 @@ package org.motechproject.nms.api.web;
 
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventRelay;
+import org.motechproject.nms.flw.service.FrontLineWorkerService;
+import org.motechproject.nms.flw.utils.FlwConstants;
 import org.motechproject.nms.imi.service.CdrFileService;
 import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
 import org.motechproject.nms.kilkari.service.SubscriptionService;
@@ -19,6 +21,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Controller to expose methods for OPS personnel
  */
@@ -31,16 +36,19 @@ public class OpsController extends BaseController {
     private SubscriptionService subscriptionService;
     private CdrFileService cdrFileService;
     private MctsWsImportService mctsWsImportService;
+    private FrontLineWorkerService frontLineWorkerService;
     private EventRelay eventRelay;
 
 
     @Autowired
     public OpsController(SubscriptionDataService subscriptionDataService, SubscriptionService subscriptionService,
-                         CdrFileService cdrFileService, MctsWsImportService mctsWsImportService, EventRelay eventRelay) {
+                         CdrFileService cdrFileService, MctsWsImportService mctsWsImportService,
+                         FrontLineWorkerService frontLineWorkerService, EventRelay eventRelay) {
         this.subscriptionDataService = subscriptionDataService;
         this.subscriptionService = subscriptionService;
         this.cdrFileService = cdrFileService;
         this.mctsWsImportService = mctsWsImportService;
+        this.frontLineWorkerService = frontLineWorkerService;
         this.eventRelay = eventRelay;
     }
 
@@ -100,11 +108,43 @@ public class OpsController extends BaseController {
         validateFieldPresent(failureReasons, "stateId", addFlwRequest.getStateId());
         validateFieldPresent(failureReasons, "districtId", addFlwRequest.getDistrictId());
         validateFieldString(failureReasons, "name", addFlwRequest.getName());
+        validateFieldString(failureReasons, "type", addFlwRequest.getType());
 
         if (failureReasons.length() > 0) {
             throw new IllegalArgumentException(failureReasons.toString());
         }
 
-        // TODO: Hook up existing flw create/update here
+        Map<String, Object> flwProperties = new HashMap<>();
+        flwProperties.put(FlwConstants.NAME, addFlwRequest.getName());
+        flwProperties.put(FlwConstants.ID, addFlwRequest.getMctsFlwId());
+        flwProperties.put(FlwConstants.CONTACT_NO, addFlwRequest.getContactNumber());
+        flwProperties.put(FlwConstants.STATE_ID, addFlwRequest.getStateId());
+        flwProperties.put(FlwConstants.DISTRICT_ID, addFlwRequest.getDistrictId());
+
+        if (addFlwRequest.getType() != null) {
+            flwProperties.put(FlwConstants.TYPE, addFlwRequest.getType());
+        }
+
+        if (addFlwRequest.getTalukaId() != null) {
+            flwProperties.put(FlwConstants.TALUKA_ID, addFlwRequest.getTalukaId());
+        }
+
+        if (addFlwRequest.getPhcId() != null) {
+            flwProperties.put(FlwConstants.PHC_ID, addFlwRequest.getPhcId());
+        }
+
+        if (addFlwRequest.getHealthblockId() != null) {
+            flwProperties.put(FlwConstants.HEALTH_BLOCK_ID, addFlwRequest.getHealthblockId());
+        }
+
+        if (addFlwRequest.getSubcentreId() != null) {
+            flwProperties.put(FlwConstants.SUB_CENTRE_ID, addFlwRequest.getSubcentreId());
+        }
+
+        if (addFlwRequest.getVillageId() != null) {
+            flwProperties.put(FlwConstants.CENSUS_VILLAGE_ID, addFlwRequest.getVillageId());
+        }
+
+        frontLineWorkerService.createUpdate(flwProperties);
     }
 }

--- a/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
@@ -2,6 +2,7 @@ package org.motechproject.nms.api.web;
 
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventRelay;
+import org.motechproject.nms.api.web.contract.AddFlwRequest;
 import org.motechproject.nms.flw.service.FrontLineWorkerService;
 import org.motechproject.nms.flw.utils.FlwConstants;
 import org.motechproject.nms.imi.service.CdrFileService;

--- a/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
@@ -7,12 +7,16 @@ import org.motechproject.nms.kilkari.repository.SubscriptionDataService;
 import org.motechproject.nms.kilkari.service.SubscriptionService;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
 import org.motechproject.nms.mcts.service.MctsWsImportService;
+import org.motechproject.nms.props.service.LogHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
@@ -79,5 +83,28 @@ public class OpsController extends BaseController {
     public void startUpkeep() {
         LOGGER.info("/upkeep");
         eventRelay.sendEventMessage(new MotechEvent(KilkariConstants.SUBSCRIPTION_UPKEEP_SUBJECT));
+    }
+
+    @RequestMapping(value = "/addFlw",
+            method = RequestMethod.POST,
+            headers = { "Content-type=application/json" })
+    @ResponseStatus(HttpStatus.OK)
+    @Transactional
+    public void createUpdateFlw(@RequestBody AddFlwRequest addFlwRequest) {
+        // TODO: obscure phone number?
+        log("REQUEST: /ops/addFlw (POST)", LogHelper.nullOrString(addFlwRequest));
+        StringBuilder failureReasons = new StringBuilder();
+        validateField10Digits(failureReasons, "contactNumber", addFlwRequest.getContactNumber());
+        validateFieldPositiveLong(failureReasons, "contactNumber", addFlwRequest.getContactNumber());
+        validateFieldPresent(failureReasons, "mctsFlwId", addFlwRequest.getMctsFlwId());
+        validateFieldPresent(failureReasons, "stateId", addFlwRequest.getStateId());
+        validateFieldPresent(failureReasons, "districtId", addFlwRequest.getDistrictId());
+        validateFieldString(failureReasons, "name", addFlwRequest.getName());
+
+        if (failureReasons.length() > 0) {
+            throw new IllegalArgumentException(failureReasons.toString());
+        }
+
+        // TODO: Hook up existing flw create/update here
     }
 }

--- a/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
@@ -32,25 +32,24 @@ import java.util.Map;
 public class OpsController extends BaseController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpsController.class);
-    private SubscriptionDataService subscriptionDataService;
-    private SubscriptionService subscriptionService;
-    private CdrFileService cdrFileService;
-    private MctsWsImportService mctsWsImportService;
-    private FrontLineWorkerService frontLineWorkerService;
-    private EventRelay eventRelay;
-
 
     @Autowired
-    public OpsController(SubscriptionDataService subscriptionDataService, SubscriptionService subscriptionService,
-                         CdrFileService cdrFileService, MctsWsImportService mctsWsImportService,
-                         FrontLineWorkerService frontLineWorkerService, EventRelay eventRelay) {
-        this.subscriptionDataService = subscriptionDataService;
-        this.subscriptionService = subscriptionService;
-        this.cdrFileService = cdrFileService;
-        this.mctsWsImportService = mctsWsImportService;
-        this.frontLineWorkerService = frontLineWorkerService;
-        this.eventRelay = eventRelay;
-    }
+    private SubscriptionDataService subscriptionDataService;
+
+    @Autowired
+    private SubscriptionService subscriptionService;
+
+    @Autowired
+    private CdrFileService cdrFileService;
+
+    @Autowired
+    private MctsWsImportService mctsWsImportService;
+
+    @Autowired
+    private FrontLineWorkerService frontLineWorkerService;
+
+    @Autowired
+    private EventRelay eventRelay;
 
     /**
      * Provided for OPS as a crutch to be able to empty all MDS cache directly after modifying the database by hand

--- a/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/OpsController.java
@@ -93,14 +93,20 @@ public class OpsController extends BaseController {
         eventRelay.sendEventMessage(new MotechEvent(KilkariConstants.SUBSCRIPTION_UPKEEP_SUBJECT));
     }
 
-    @RequestMapping(value = "/addFlw",
+    @RequestMapping(value = "/createUpdateFlw",
             method = RequestMethod.POST,
             headers = { "Content-type=application/json" })
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     public void createUpdateFlw(@RequestBody AddFlwRequest addFlwRequest) {
-        // TODO: obscure phone number?
-        log("REQUEST: /ops/addFlw (POST)", LogHelper.nullOrString(addFlwRequest));
+        log("REQUEST: /ops/createUpdateFlw", String.format(
+                "callingNumber=%s, mctsId=%s, name=%s, state=%d, district=%d",
+                LogHelper.obscure(addFlwRequest.getContactNumber()),
+                addFlwRequest.getMctsFlwId(),
+                addFlwRequest.getName(),
+                addFlwRequest.getStateId(),
+                addFlwRequest.getDistrictId()));
+
         StringBuilder failureReasons = new StringBuilder();
         validateField10Digits(failureReasons, "contactNumber", addFlwRequest.getContactNumber());
         validateFieldPositiveLong(failureReasons, "contactNumber", addFlwRequest.getContactNumber());

--- a/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
@@ -8,8 +8,8 @@ public class AddFlwRequest {
     private String name;
     private String mctsFlwId;
     private Long contactNumber;
-    private Integer stateId;
-    private Integer districtId;
+    private Long stateId;
+    private Long districtId;
     private String talukaId;
     private Integer phcId;
     private Integer subcentreId;
@@ -45,19 +45,19 @@ public class AddFlwRequest {
         this.contactNumber = contactNumber;
     }
 
-    public Integer getStateId() {
+    public Long getStateId() {
         return stateId;
     }
 
-    public void setStateId(Integer stateId) {
+    public void setStateId(Long stateId) {
         this.stateId = stateId;
     }
 
-    public Integer getDistrictId() {
+    public Long getDistrictId() {
         return districtId;
     }
 
-    public void setDistrictId(Integer districtId) {
+    public void setDistrictId(Long districtId) {
         this.districtId = districtId;
     }
 

--- a/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
@@ -1,4 +1,4 @@
-package org.motechproject.nms.api.web;
+package org.motechproject.nms.api.web.contract;
 
 /**
  * Request body for creating or updating an flw

--- a/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
+++ b/api/src/main/java/org/motechproject/nms/api/web/contract/AddFlwRequest.java
@@ -11,10 +11,10 @@ public class AddFlwRequest {
     private Long stateId;
     private Long districtId;
     private String talukaId;
-    private Integer phcId;
-    private Integer subcentreId;
-    private Integer villageId;
-    private Integer healthblockId;
+    private Long phcId;
+    private Long subcentreId;
+    private Long villageId;
+    private Long healthblockId;
     private String type;
 
     public AddFlwRequest() {
@@ -69,35 +69,35 @@ public class AddFlwRequest {
         this.talukaId = talukaId;
     }
 
-    public Integer getPhcId() {
+    public Long getPhcId() {
         return phcId;
     }
 
-    public void setPhcId(Integer phcId) {
+    public void setPhcId(Long phcId) {
         this.phcId = phcId;
     }
 
-    public Integer getSubcentreId() {
+    public Long getSubcentreId() {
         return subcentreId;
     }
 
-    public void setSubcentreId(Integer subcentreId) {
+    public void setSubcentreId(Long subcentreId) {
         this.subcentreId = subcentreId;
     }
 
-    public Integer getVillageId() {
+    public Long getVillageId() {
         return villageId;
     }
 
-    public void setVillageId(Integer villageId) {
+    public void setVillageId(Long villageId) {
         this.villageId = villageId;
     }
 
-    public Integer getHealthblockId() {
+    public Long getHealthblockId() {
         return healthblockId;
     }
 
-    public void setHealthblockId(Integer healthblockId) {
+    public void setHealthblockId(Long healthblockId) {
         this.healthblockId = healthblockId;
     }
 

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
@@ -52,11 +52,11 @@ public class FlwError {
         this.districtId = districtId;
     }
 
-    public FlwErrorReason getError() {
+    public FlwErrorReason getReason() {
         return reason;
     }
 
-    public void setError(FlwErrorReason error) {
-        this.reason = error;
+    public void setReason(FlwErrorReason reason) {
+        this.reason = reason;
     }
 }

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
@@ -1,0 +1,62 @@
+package org.motechproject.nms.flw.domain;
+
+import org.motechproject.mds.annotations.Entity;
+import org.motechproject.mds.annotations.Field;
+
+/**
+ * Audit log object for tracking failed FLW updates
+ */
+@Entity(tableName = "nms_flw_errors")
+public class FlwError {
+
+    @Field
+    private String mctsId;
+
+    @Field
+    private Long stateId;
+
+    @Field
+    private Long districtId;
+
+    @Field
+    private String error;
+
+    public FlwError(String mctsId, Long stateId, Long districtId, String error) {
+        this.mctsId = mctsId;
+        this.stateId = stateId;
+        this.districtId = districtId;
+        this.error = error;
+    }
+
+    public String getMctsId() {
+        return mctsId;
+    }
+
+    public void setMctsId(String mctsId) {
+        this.mctsId = mctsId;
+    }
+
+    public Long getStateId() {
+        return stateId;
+    }
+
+    public void setStateId(Long stateId) {
+        this.stateId = stateId;
+    }
+
+    public Long getDistrictId() {
+        return districtId;
+    }
+
+    public void setDistrictId(Long districtId) {
+        this.districtId = districtId;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FlwError.java
@@ -19,13 +19,13 @@ public class FlwError {
     private Long districtId;
 
     @Field
-    private String error;
+    private FlwErrorReason reason;
 
-    public FlwError(String mctsId, Long stateId, Long districtId, String error) {
+    public FlwError(String mctsId, Long stateId, Long districtId, FlwErrorReason reason) {
         this.mctsId = mctsId;
         this.stateId = stateId;
         this.districtId = districtId;
-        this.error = error;
+        this.reason = reason;
     }
 
     public String getMctsId() {
@@ -52,11 +52,11 @@ public class FlwError {
         this.districtId = districtId;
     }
 
-    public String getError() {
-        return error;
+    public FlwErrorReason getError() {
+        return reason;
     }
 
-    public void setError(String error) {
-        this.error = error;
+    public void setError(FlwErrorReason error) {
+        this.reason = error;
     }
 }

--- a/flw/src/main/java/org/motechproject/nms/flw/domain/FlwErrorReason.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/domain/FlwErrorReason.java
@@ -1,0 +1,13 @@
+package org.motechproject.nms.flw.domain;
+
+/**
+ * Reason codes for flw sync errors
+ */
+public enum FlwErrorReason {
+    PHONE_NUMBER_IN_USE,
+    INVALID_PHONE_NUMBER,
+    INVALID_LOCATION_STATE,
+    INVALID_LOCATION_DISTRICT,
+    INVALID_LOCATION_TALUKA,
+    UNKNOWN
+}

--- a/flw/src/main/java/org/motechproject/nms/flw/repository/FlwErrorDataService.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/repository/FlwErrorDataService.java
@@ -1,10 +1,19 @@
 package org.motechproject.nms.flw.repository;
 
+import org.motechproject.mds.annotations.Lookup;
+import org.motechproject.mds.annotations.LookupField;
 import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.nms.flw.domain.FlwError;
+
+import java.util.List;
 
 /**
  * Data service to add flw sync error audit logs
  */
 public interface FlwErrorDataService extends MotechDataService<FlwError> {
+
+    @Lookup
+    List<FlwError> findByMctsId(@LookupField(name = "mctsId") String mctsId,
+                                @LookupField(name = "stateId") Long stateId,
+                                @LookupField(name = "districtId") Long districtId);
 }

--- a/flw/src/main/java/org/motechproject/nms/flw/repository/FlwErrorDataService.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/repository/FlwErrorDataService.java
@@ -1,0 +1,10 @@
+package org.motechproject.nms.flw.repository;
+
+import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.nms.flw.domain.FlwError;
+
+/**
+ * Data service to add flw sync error audit logs
+ */
+public interface FlwErrorDataService extends MotechDataService<FlwError> {
+}

--- a/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/FrontLineWorkerService.java
@@ -7,6 +7,7 @@ import org.motechproject.nms.flw.domain.FrontLineWorker;
 import org.motechproject.nms.region.domain.State;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Simple example of a service interface.
@@ -14,6 +15,12 @@ import java.util.List;
 public interface FrontLineWorkerService {
 
     State getState(FrontLineWorker frontLineWorker);
+
+    /**
+     * Used to create or update an FLW from mcts or other sync services
+     * @param flwRecord key-value pair of properties for flw
+     */
+    boolean createUpdate(Map<String, Object> flwRecord);
 
     void add(FrontLineWorker frontLineWorker);
 

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -210,10 +210,20 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
                 update(FlwMapper.updateFlw(existingFlwByMctsFlwId, flw, location));
                 return true;
             } else if (existingFlwByMctsFlwId == null && existingFlwByNumber != null) {
-                // phone number used by someone else.
-                LOGGER.debug("New flw but phone number(update) already in use");
-                flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.PHONE_NUMBER_IN_USE));
-                return false;
+
+                if (existingFlwByNumber.getMctsFlwId() == null) {
+                    // we just got data from mcts for a previous anonymous user that subscribed by phone number
+                    // merging those records
+                    LOGGER.debug("Merging mcts data with previously anonymous user");
+                    update(FlwMapper.updateFlw(existingFlwByNumber, flw, location));
+                    return true;
+                } else {
+                    // phone number used by someone else.
+                    LOGGER.debug("New flw but phone number(update) already in use");
+                    flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.PHONE_NUMBER_IN_USE));
+                    return false;
+                }
+
             } else { // existingFlwByMctsFlwId & existingFlwByNumber are null)
                 // new user. set fields and add
                 LOGGER.debug("Adding new flw user");

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -186,7 +186,7 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
         FrontLineWorker existingFlwByMctsFlwId = getByMctsFlwIdAndState(mctsFlwId, state);
         Map<String, Object> location = new HashMap<>();
         try {
-            location = locationService.getLocations(flw);
+            location = locationService.getLocations(flw, false);
 
             if (existingFlwByMctsFlwId != null && existingFlwByNumber != null) {
 

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -203,6 +203,8 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
                 }
             } else if (existingFlwByMctsFlwId != null && existingFlwByNumber == null) {
                 // trying to update the phone number of the person. possible migration scenario
+                // making design decision that flw will lose all progress when phone number is changed. Usage and tracking is not
+                // worth the effort & we don't really know that its the same flw
                 LOGGER.debug("Updating phone number for flw");
                 update(FlwMapper.updateFlw(existingFlwByMctsFlwId, flw, location));
                 return true;

--- a/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/service/impl/FrontLineWorkerServiceImpl.java
@@ -9,6 +9,7 @@ import org.motechproject.event.listener.annotations.MotechListener;
 import org.motechproject.mds.query.QueryExecution;
 import org.motechproject.mds.util.InstanceSecurityRestriction;
 import org.motechproject.nms.flw.domain.FlwError;
+import org.motechproject.nms.flw.domain.FlwErrorReason;
 import org.motechproject.nms.flw.domain.FrontLineWorker;
 import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
 import org.motechproject.nms.flw.repository.FlwErrorDataService;
@@ -172,12 +173,12 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
 
         State state = locationService.getState(stateId);
         if (state == null) {
-            flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, "State doesn't exist for stateId"));
+            flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.INVALID_LOCATION_STATE));
             return false;
         }
         District district = locationService.getDistrict(stateId, districtId);
         if (district == null) {
-            flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, "district doesn't exist for districtId"));
+            flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.INVALID_LOCATION_DISTRICT));
             return false;
         }
 
@@ -198,7 +199,7 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
                 } else {
                     // we are trying to update 2 different users and/or phone number used by someone else
                     LOGGER.debug("Existing flw but phone number(update) already in use");
-                    flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, "Phone number used by someone else"));
+                    flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.PHONE_NUMBER_IN_USE));
                     return false;
                 }
             } else if (existingFlwByMctsFlwId != null && existingFlwByNumber == null) {
@@ -211,7 +212,7 @@ public class FrontLineWorkerServiceImpl implements FrontLineWorkerService {
             } else if (existingFlwByMctsFlwId == null && existingFlwByNumber != null) {
                 // phone number used by someone else.
                 LOGGER.debug("New flw but phone number(update) already in use");
-                flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, "Phone number used by someone else"));
+                flwErrorDataService.create(new FlwError(mctsFlwId, stateId, districtId, FlwErrorReason.PHONE_NUMBER_IN_USE));
                 return false;
             } else { // existingFlwByMctsFlwId & existingFlwByNumber are null)
                 // new user. set fields and add

--- a/flw/src/main/java/org/motechproject/nms/flw/utils/FlwConstants.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/utils/FlwConstants.java
@@ -6,6 +6,7 @@ public final class FlwConstants {
     public static final String CONTACT_NO = "Contact_No";
     public static final String NAME = "Name";
     public static final String STATE_ID = "StateID";
+    public static final String STATE_NAME = "State_Name";
     public static final String DISTRICT_ID = "District_ID";
     public static final String DISTRICT_NAME = "District_Name";
     public static final String TALUKA_ID = "Taluka_ID";

--- a/flw/src/main/java/org/motechproject/nms/flw/utils/FlwMapper.java
+++ b/flw/src/main/java/org/motechproject/nms/flw/utils/FlwMapper.java
@@ -1,0 +1,89 @@
+package org.motechproject.nms.flw.utils;
+
+import org.motechproject.nms.flw.domain.FrontLineWorker;
+import org.motechproject.nms.flw.domain.FrontLineWorkerStatus;
+import org.motechproject.nms.region.domain.State;
+import org.motechproject.nms.region.domain.District;
+import org.motechproject.nms.region.domain.Taluka;
+import org.motechproject.nms.region.domain.HealthBlock;
+import org.motechproject.nms.region.domain.HealthFacility;
+import org.motechproject.nms.region.domain.HealthSubFacility;
+import org.motechproject.nms.region.domain.Village;
+import org.motechproject.nms.region.exception.InvalidLocationException;
+
+import java.util.Map;
+
+/**
+ * Helper class to set flw properties
+ */
+public final class FlwMapper {
+
+    private FlwMapper() { }
+
+    public static FrontLineWorker createFlw(Map<String, Object> record, Map<String, Object> location)
+            throws InvalidLocationException {
+        Long contactNumber = (Long) record.get(FlwConstants.CONTACT_NO);
+
+        FrontLineWorker flw = new FrontLineWorker(contactNumber);
+        flw.setStatus(FrontLineWorkerStatus.INACTIVE);
+
+        return updateFlw(flw, record, location);
+    }
+
+
+    public static FrontLineWorker updateFlw(FrontLineWorker flw, Map<String, Object> record, Map<String, Object> location)
+            throws InvalidLocationException {
+
+        String mctsFlwId = (String) record.get(FlwConstants.ID);
+        Long contactNumber = (Long) record.get(FlwConstants.CONTACT_NO);
+        String name = (String) record.get(FlwConstants.NAME);
+        String type = (String) record.get(FlwConstants.TYPE);
+
+        if (contactNumber != null) {
+            flw.setContactNumber(contactNumber);
+        }
+
+        if (mctsFlwId != null) {
+            flw.setMctsFlwId(mctsFlwId);
+        }
+
+        if (name != null) {
+            flw.setName(name);
+        }
+
+        setFrontLineWorkerLocation(flw, location);
+
+        if (flw.getLanguage() == null) {
+            flw.setLanguage(flw.getDistrict().getLanguage());
+        }
+
+        if (flw.getDesignation() == null) {
+            flw.setDesignation(type);
+        }
+
+        return flw;
+    }
+
+    public static FrontLineWorker setFrontLineWorkerLocation(FrontLineWorker flw, Map<String, Object> locations) throws InvalidLocationException {
+        if (locations.get(FlwConstants.STATE_ID) == null && locations.get(FlwConstants.DISTRICT_ID) == null) {
+            throw new InvalidLocationException("Missing mandatory state and district fields");
+        }
+
+        if (locations.get(FlwConstants.STATE_ID) == null) {
+            throw new InvalidLocationException("Missing mandatory state field");
+        }
+
+        if (locations.get(FlwConstants.DISTRICT_ID) == null) {
+            throw new InvalidLocationException("Missing mandatory district field");
+        }
+
+        flw.setState((State) locations.get(FlwConstants.STATE_ID));
+        flw.setDistrict((District) locations.get(FlwConstants.DISTRICT_ID));
+        flw.setTaluka((Taluka) locations.get(FlwConstants.TALUKA_ID));
+        flw.setHealthBlock((HealthBlock) locations.get(FlwConstants.HEALTH_BLOCK_ID));
+        flw.setHealthFacility((HealthFacility) locations.get(FlwConstants.PHC_ID));
+        flw.setHealthSubFacility((HealthSubFacility) locations.get(FlwConstants.SUB_CENTRE_ID));
+        flw.setVillage((Village) locations.get(FlwConstants.CENSUS_VILLAGE_ID + FlwConstants.NON_CENSUS_VILLAGE_ID));
+        return flw;
+    }
+}

--- a/flw/src/main/resources/META-INF/spring/blueprint.xml
+++ b/flw/src/main/resources/META-INF/spring/blueprint.xml
@@ -39,6 +39,9 @@
     <osgi:service ref="frontLineWorkerUpdateImportService"
                   interface="org.motechproject.nms.flw.service.FrontLineWorkerUpdateImportService" />
 
+    <osgi:reference id="flwErrorDataService"
+                    interface="org.motechproject.nms.flw.repository.FlwErrorDataService" />
+
     <osgi:reference id="frontLineWorkerDataService"
                     interface="org.motechproject.nms.flw.repository.FrontLineWorkerDataService" />
 

--- a/region/src/main/java/org/motechproject/nms/region/service/LocationService.java
+++ b/region/src/main/java/org/motechproject/nms/region/service/LocationService.java
@@ -24,6 +24,15 @@ public interface LocationService {
      */
     Map<String, Object> getLocations(Map<String, Object> locationMapping) throws InvalidLocationException;
 
+    /**
+     * Get locations method that fetches the associated location code from the mapping
+     * @param locationMapping mapping codes for location hierarchy
+     * @param createIfNotExist creates the location hierarchy if it doesnt exist already
+     * @return mapping of code to location object
+     * @throws InvalidLocationException when the map of code set violates the location hierarchy
+     */
+    Map<String, Object> getLocations(Map<String, Object> locationMapping, boolean createIfNotExist) throws InvalidLocationException;
+
     State getState(Long stateId);
 
     District getDistrict(Long stateId, Long districtId);

--- a/region/src/main/java/org/motechproject/nms/region/service/impl/LocationServiceImpl.java
+++ b/region/src/main/java/org/motechproject/nms/region/service/impl/LocationServiceImpl.java
@@ -89,10 +89,13 @@ public class LocationServiceImpl implements LocationService {
         return !"0".equals(obj);
     }
 
+    public Map<String, Object> getLocations(Map<String, Object> map) throws InvalidLocationException {
+       return getLocations(map, true);
+    }
 
     @Override // NO CHECKSTYLE Cyclomatic Complexity
     @SuppressWarnings("PMD")
-    public Map<String, Object> getLocations(Map<String, Object> map) throws InvalidLocationException {
+    public Map<String, Object> getLocations(Map<String, Object> map, boolean createIfNotExists) throws InvalidLocationException {
 
         Map<String, Object> locations = new HashMap<>();
 
@@ -123,7 +126,7 @@ public class LocationServiceImpl implements LocationService {
             return locations;
         }
         Taluka taluka = talukaService.findByDistrictAndCode(district, (String) map.get(TALUKA_ID));
-        if (taluka == null) {
+        if (taluka == null && createIfNotExists) {
             taluka = new Taluka();
             taluka.setCode((String) map.get(TALUKA_ID));
             taluka.setName((String) map.get(TALUKA_NAME));
@@ -139,7 +142,7 @@ public class LocationServiceImpl implements LocationService {
         Long vcode = map.get(VILLAGE_ID) == null ? 0 : (Long) map.get(VILLAGE_ID);
         if (vcode != 0 || svid != 0) {
             Village village = villageService.findByTalukaAndVcodeAndSvid(taluka, vcode, svid);
-            if (village == null) {
+            if (village == null && createIfNotExists) {
                 village = new Village();
                 village.setSvid(svid);
                 village.setVcode(vcode);
@@ -157,7 +160,7 @@ public class LocationServiceImpl implements LocationService {
             return locations;
         }
         HealthBlock healthBlock = healthBlockService.findByTalukaAndCode(taluka, (Long) map.get(HEALTHBLOCK_ID));
-        if (healthBlock == null) {
+        if (healthBlock == null && createIfNotExists) {
             healthBlock = new HealthBlock();
             healthBlock.setTaluka(taluka);
             healthBlock.setCode((Long) map.get(HEALTHBLOCK_ID));
@@ -173,7 +176,7 @@ public class LocationServiceImpl implements LocationService {
             return locations;
         }
         HealthFacility healthFacility = healthFacilityService.findByHealthBlockAndCode(healthBlock, (Long) map.get(PHC_ID));
-        if (healthFacility == null) {
+        if (healthFacility == null && createIfNotExists) {
             healthFacility = new HealthFacility();
             healthFacility.setHealthBlock(healthBlock);
             healthFacility.setCode((Long) map.get(PHC_ID));
@@ -189,7 +192,7 @@ public class LocationServiceImpl implements LocationService {
             return locations;
         }
         HealthSubFacility healthSubFacility = healthSubFacilityService.findByHealthFacilityAndCode(healthFacility, (Long) map.get(SUBCENTRE_ID));
-        if (healthSubFacility == null) {
+        if (healthSubFacility == null && createIfNotExists) {
             healthSubFacility = new HealthSubFacility();
             healthSubFacility.setHealthFacility(healthFacility);
             healthSubFacility.setCode((Long) map.get(SUBCENTRE_ID));

--- a/testing/src/main/java/org/motechproject/nms/testing/service/impl/TestingServiceImpl.java
+++ b/testing/src/main/java/org/motechproject/nms/testing/service/impl/TestingServiceImpl.java
@@ -86,6 +86,7 @@ public class TestingServiceImpl implements TestingService {
         "nms_flw_cdrs__TRASH",
         "nms_front_line_workers",
         "nms_front_line_workers__TRASH",
+        "nms_flw_errors",
         "nms_health_blocks",
         "nms_health_blocks__TRASH",
         "nms_health_facilities",

--- a/testing/src/test/java/org/motechproject/nms/testing/it/IntegrationTests.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/IntegrationTests.java
@@ -6,6 +6,7 @@ import org.motechproject.nms.testing.it.api.CallDetailsControllerBundleIT;
 import org.motechproject.nms.testing.it.api.KilkariControllerBundleIT;
 import org.motechproject.nms.testing.it.api.LanguageControllerBundleIT;
 import org.motechproject.nms.testing.it.api.MobileAcademyControllerBundleIT;
+import org.motechproject.nms.testing.it.api.OpsControllerBundleIT;
 import org.motechproject.nms.testing.it.api.UserControllerBundleIT;
 import org.motechproject.nms.testing.it.flw.FrontLineWorkerImportServiceBundleIT;
 import org.motechproject.nms.testing.it.flw.FrontLineWorkerServiceBundleIT;
@@ -47,6 +48,7 @@ import org.motechproject.nms.testing.it.tracking.TrackOneToManyChangesBundleIT;
     CallDetailsControllerBundleIT.class,
     KilkariControllerBundleIT.class,
     MobileAcademyControllerBundleIT.class,
+    OpsControllerBundleIT.class,
 
     /**
      * FLW

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 @ExamFactory(MotechNativeTestContainerFactory.class)
 public class OpsControllerBundleIT extends BasePaxIT {
 
-    private String addFlwEndpoint = String.format("http://localhost:%d/api/ops/addFlw",
+    private String addFlwEndpoint = String.format("http://localhost:%d/api/ops/createUpdateFlw",
             TestContext.getJettyPort());
     State state;
     District district;
@@ -83,27 +83,6 @@ public class OpsControllerBundleIT extends BasePaxIT {
 
     @Inject
     StateDataService stateDataService;
-
-    @Inject
-    DistrictDataService districtDataService;
-
-    @Inject
-    TalukaDataService talukaDataService;
-
-    @Inject
-    VillageDataService villageDataService;
-
-    @Inject
-    HealthBlockDataService healthBlockDataService;
-
-    @Inject
-    HealthBlockService healthBlockService;
-
-    @Inject
-    HealthFacilityDataService healthFacilityDataService;
-
-    @Inject
-    HealthSubFacilityDataService healthSubFacilityDataService;
 
     @Inject
     FrontLineWorkerDataService frontLineWorkerDataService;

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -195,6 +195,21 @@ public class OpsControllerBundleIT extends BasePaxIT {
         assertEquals(flwErrors.get(0).getReason(), FlwErrorReason.PHONE_NUMBER_IN_USE);
     }
 
+    // Test flw update to an existing used phone number by someone else
+    @Test
+    public void testUpdateFlwAnonymousMctsMerge() throws IOException, InterruptedException {
+
+        // create flw with null mcts id
+        createFlwHelper("Chinkoo Devi", 9876543210L, null);
+
+        AddFlwRequest updateRequest = getAddRequest();
+        HttpPost httpRequest = RequestBuilder.createPostRequest(addFlwEndpoint, updateRequest);
+        assertTrue(SimpleHttpClient.execHttpRequest(httpRequest, HttpStatus.SC_OK, RequestBuilder.ADMIN_USERNAME, RequestBuilder.ADMIN_PASSWORD));
+
+        FrontLineWorker flwByNumber = frontLineWorkerDataService.findByContactNumber(9876543210L);
+        assertEquals("Anonymous user was not merged", updateRequest.getMctsFlwId(), flwByNumber.getMctsFlwId());
+    }
+
 
     @Test
     public void testUpdateNoState() throws IOException, InterruptedException {
@@ -248,7 +263,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
         assertEquals(flwErrors.get(0).getReason(), FlwErrorReason.INVALID_LOCATION_DISTRICT);
     }
 
-    private void createFlwHelper(String name, long phoneNumber, String mctsFlwId) {
+    private void createFlwHelper(String name, Long phoneNumber, String mctsFlwId) {
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
         stateDataService.create(state);
         // create flw

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -136,6 +136,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
     @Test
     public void testUpdateFlwName() throws IOException, InterruptedException {
 
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
         // create flw
         FrontLineWorker flw = new FrontLineWorker("Kookoo Devi" ,9876543210L);
         flw.setMctsFlwId("123");
@@ -143,6 +144,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
         flw.setDistrict(district);
         flw.setLanguage(language);
         frontLineWorkerDataService.create(flw);
+        transactionManager.commit(status);
 
         AddFlwRequest updateRequest = getAddRequest();
         HttpPost httpRequest = RequestBuilder.createPostRequest(addFlwEndpoint, updateRequest);
@@ -153,6 +155,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
     @Test
     public void testUpdateFlwPhoneOpen() throws IOException, InterruptedException {
 
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
         // create flw
         FrontLineWorker flw = new FrontLineWorker("Kookoo Devi" ,9876543210L);
         flw.setMctsFlwId("123");
@@ -160,6 +163,8 @@ public class OpsControllerBundleIT extends BasePaxIT {
         flw.setDistrict(district);
         flw.setLanguage(language);
         frontLineWorkerDataService.create(flw);
+        transactionManager.commit(status);
+
 
         AddFlwRequest updateRequest = getAddRequest();
         updateRequest.setContactNumber(9876543211L);    // update
@@ -171,6 +176,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
     @Test
     public void testUpdateFlwPhoneOccupied() throws IOException, InterruptedException {
 
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
         // create flw
         FrontLineWorker flw = new FrontLineWorker("Kookoo Devi" ,9876543210L);
         flw.setMctsFlwId("456");
@@ -178,6 +184,7 @@ public class OpsControllerBundleIT extends BasePaxIT {
         flw.setDistrict(district);
         flw.setLanguage(language);
         frontLineWorkerDataService.create(flw);
+        transactionManager.commit(status);
 
         AddFlwRequest updateRequest = getAddRequest();
         HttpPost httpRequest = RequestBuilder.createPostRequest(addFlwEndpoint, updateRequest);
@@ -200,6 +207,8 @@ public class OpsControllerBundleIT extends BasePaxIT {
 
     // helper to create location data
     private void initializeLocationData() {
+
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
 
         healthSubFacility = new HealthSubFacility();
         healthSubFacility.setName("Health Sub Facility 1");
@@ -251,6 +260,8 @@ public class OpsControllerBundleIT extends BasePaxIT {
         language = languageDataService.create(new Language("15", "HINDI_DEFAULT"));
         district.setLanguage(language);
         stateDataService.create(state);
+
+        transactionManager.commit(status);
     }
 
 }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -5,7 +5,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.motechproject.nms.api.web.AddFlwRequest;
+import org.motechproject.nms.api.web.contract.AddFlwRequest;
 import org.motechproject.nms.testing.it.api.utils.RequestBuilder;
 import org.motechproject.nms.testing.service.TestingService;
 import org.motechproject.testing.osgi.BasePaxIT;

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -1,0 +1,48 @@
+package org.motechproject.nms.testing.it.api;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.motechproject.nms.api.web.AddFlwRequest;
+import org.motechproject.nms.testing.it.api.utils.RequestBuilder;
+import org.motechproject.nms.testing.service.TestingService;
+import org.motechproject.testing.osgi.BasePaxIT;
+import org.motechproject.testing.osgi.container.MotechNativeTestContainerFactory;
+import org.motechproject.testing.osgi.http.SimpleHttpClient;
+import org.motechproject.testing.utils.TestContext;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for Ops controller
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+@ExamFactory(MotechNativeTestContainerFactory.class)
+public class OpsControllerBundleIT extends BasePaxIT {
+
+    private String addFlwEndpoint = String.format("http://localhost:%d/api/ops/addFlw",
+            TestContext.getJettyPort());
+    @Inject
+    TestingService testingService;
+
+    @Before
+    public void setupTestData() {
+        testingService.clearDatabase();
+    }
+
+    @Test
+    public void testBadAddFlwRequest() throws IOException, InterruptedException {
+        HttpPost request = RequestBuilder.createPostRequest(addFlwEndpoint, new AddFlwRequest());
+        assertTrue(SimpleHttpClient.execHttpRequest(request, HttpStatus.SC_BAD_REQUEST, RequestBuilder.ADMIN_USERNAME, RequestBuilder.ADMIN_PASSWORD));
+    }
+}

--- a/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/api/OpsControllerBundleIT.java
@@ -6,6 +6,25 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.motechproject.nms.api.web.contract.AddFlwRequest;
+import org.motechproject.nms.region.domain.District;
+import org.motechproject.nms.region.domain.HealthBlock;
+import org.motechproject.nms.region.domain.HealthFacility;
+import org.motechproject.nms.region.domain.HealthFacilityType;
+import org.motechproject.nms.region.domain.HealthSubFacility;
+import org.motechproject.nms.region.domain.Language;
+import org.motechproject.nms.region.domain.State;
+import org.motechproject.nms.region.domain.Taluka;
+import org.motechproject.nms.region.domain.Village;
+import org.motechproject.nms.region.repository.DistrictDataService;
+import org.motechproject.nms.region.repository.HealthBlockDataService;
+import org.motechproject.nms.region.repository.HealthFacilityDataService;
+import org.motechproject.nms.region.repository.HealthFacilityTypeDataService;
+import org.motechproject.nms.region.repository.HealthSubFacilityDataService;
+import org.motechproject.nms.region.repository.LanguageDataService;
+import org.motechproject.nms.region.repository.StateDataService;
+import org.motechproject.nms.region.repository.TalukaDataService;
+import org.motechproject.nms.region.repository.VillageDataService;
+import org.motechproject.nms.region.service.HealthBlockService;
 import org.motechproject.nms.testing.it.api.utils.RequestBuilder;
 import org.motechproject.nms.testing.service.TestingService;
 import org.motechproject.testing.osgi.BasePaxIT;
@@ -16,6 +35,9 @@ import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -32,17 +54,138 @@ public class OpsControllerBundleIT extends BasePaxIT {
 
     private String addFlwEndpoint = String.format("http://localhost:%d/api/ops/addFlw",
             TestContext.getJettyPort());
+    State state;
+    District district;
+    Taluka taluka;
+    Village village;
+    HealthBlock healthBlock;
+    HealthFacilityType healthFacilityType;
+    HealthFacility healthFacility;
+    HealthSubFacility healthSubFacility;
+
+    @Inject
+    PlatformTransactionManager transactionManager;
+
     @Inject
     TestingService testingService;
+
+    @Inject
+    LanguageDataService languageDataService;
+
+    @Inject
+    StateDataService stateDataService;
+
+    @Inject
+    DistrictDataService districtDataService;
+
+    @Inject
+    TalukaDataService talukaDataService;
+
+    @Inject
+    VillageDataService villageDataService;
+
+    @Inject
+    HealthBlockDataService healthBlockDataService;
+
+    @Inject
+    HealthBlockService healthBlockService;
+
+    @Inject
+    HealthFacilityDataService healthFacilityDataService;
+
+    @Inject
+    HealthSubFacilityDataService healthSubFacilityDataService;
 
     @Before
     public void setupTestData() {
         testingService.clearDatabase();
+        initializeLocationData();
     }
 
     @Test
-    public void testBadAddFlwRequest() throws IOException, InterruptedException {
+    public void testEmptyAddFlwRequest() throws IOException, InterruptedException {
         HttpPost request = RequestBuilder.createPostRequest(addFlwEndpoint, new AddFlwRequest());
         assertTrue(SimpleHttpClient.execHttpRequest(request, HttpStatus.SC_BAD_REQUEST, RequestBuilder.ADMIN_USERNAME, RequestBuilder.ADMIN_PASSWORD));
     }
+
+    @Test
+    public void testBadContactNumberAddFlwRequest() throws IOException, InterruptedException {
+        AddFlwRequest addRequest = new AddFlwRequest();
+        addRequest.setContactNumber(9876543210L);
+        HttpPost httpRequest = RequestBuilder.createPostRequest(addFlwEndpoint, addRequest);
+        assertTrue(SimpleHttpClient.execHttpRequest(httpRequest, HttpStatus.SC_BAD_REQUEST, RequestBuilder.ADMIN_USERNAME, RequestBuilder.ADMIN_PASSWORD));
+    }
+
+    @Test
+    public void testCreateNewFlw() throws IOException, InterruptedException {
+        AddFlwRequest addFlwRequest = getAddRequest();
+        HttpPost httpRequest = RequestBuilder.createPostRequest(addFlwEndpoint, addFlwRequest);
+        assertTrue(SimpleHttpClient.execHttpRequest(httpRequest, HttpStatus.SC_OK, RequestBuilder.ADMIN_USERNAME, RequestBuilder.ADMIN_PASSWORD));
+    }
+
+    private AddFlwRequest getAddRequest() {
+        AddFlwRequest request = new AddFlwRequest();
+        request.setContactNumber(9876543210L);
+        request.setName("Chinkoo Devi");
+        request.setMctsFlwId("123");
+        request.setStateId(state.getCode());
+        request.setDistrictId(district.getCode());
+        request.setType("ANM");
+        return request;
+    }
+
+    private void initializeLocationData() {
+
+        healthSubFacility = new HealthSubFacility();
+        healthSubFacility.setName("Health Sub Facility 1");
+        healthSubFacility.setRegionalName("Health Sub Facility 1");
+        healthSubFacility.setCode(1L);
+
+        healthFacilityType = new HealthFacilityType();
+        healthFacilityType.setName("Health Facility Type 1");
+        healthFacilityType.setCode(1L);
+
+        healthFacility = new HealthFacility();
+        healthFacility.setName("Health Facility 1");
+        healthFacility.setRegionalName("Health Facility 1");
+        healthFacility.setCode(1L);
+        healthFacility.setHealthFacilityType(healthFacilityType);
+        healthFacility.getHealthSubFacilities().add(healthSubFacility);
+
+        healthBlock = new HealthBlock();
+        healthBlock.setName("Health Block 1");
+        healthBlock.setRegionalName("Health Block 1");
+        healthBlock.setHq("Health Block 1 HQ");
+        healthBlock.setCode(1L);
+        healthBlock.getHealthFacilities().add(healthFacility);
+
+        village = new Village();
+        village.setName("Village 1");
+        village.setRegionalName("Village 1");
+        village.setVcode(1L);
+
+        taluka = new Taluka();
+        taluka.setName("Taluka 1");
+        taluka.setRegionalName("Taluka 1");
+        taluka.setIdentity(1);
+        taluka.setCode("0004");
+        taluka.getVillages().add(village);
+        taluka.getHealthBlocks().add(healthBlock);
+
+        district = new District();
+        district.setName("District 1");
+        district.setRegionalName("District 1");
+        district.setCode(1L);
+        district.getTalukas().add(taluka);
+
+        state = new State();
+        state.setName("State 1");
+        state.setCode(1L);
+        state.getDistricts().add(district);
+
+        Language language = new Language("15", "HINDI_DEFAULT");
+        district.setLanguage(languageDataService.create(language));
+        stateDataService.create(state);
+    }
+
 }

--- a/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/MctsBeneficiaryUpdateServiceBundleIT.java
+++ b/testing/src/test/java/org/motechproject/nms/testing/it/kilkari/MctsBeneficiaryUpdateServiceBundleIT.java
@@ -521,7 +521,7 @@ public class MctsBeneficiaryUpdateServiceBundleIT extends BasePaxIT {
         assertEquals(453L, (long) updatedMother3.getHealthBlock().getCode());
 
         // DOB update:
-        String updatedDOB = "01-07-2015";
+        String updatedDOB = "01-12-2015";
         Subscriber subscriber4 = subscriberDataService.findByNumber(child4msisdn);
         assertEquals(updatedDOB, getDateString(subscriber4.getDateOfBirth()));
         Subscription updatedSubscription = subscriber4.getActiveAndPendingSubscriptions().iterator().next();

--- a/testing/src/test/resources/csv/mcts_beneficiary_update.csv
+++ b/testing/src/test/resources/csv/mcts_beneficiary_update.csv
@@ -2,4 +2,4 @@ Sr No,MCTS ID,STATE ID,Beneficiary New DOB change,Beneficiary New LMP change,Sta
 1,1234567890,,,,21,3,,,,,,,,,,,,,9439986187
 2,1234567899,,,,21,3,,,,,,,,,,,,,9439986188
 3,9876543210,,,01-11-2015,21,3,0026,,453,,,,,,,,,,9439986199
-4,9876543211,,01-07-2015,,21,3,111,Taluka,222,HealthBlock_Name,333,PHC,444,SubCentre,555,Village,,,9439986200
+4,9876543211,,01-12-2015,,21,3,111,Taluka,222,HealthBlock_Name,333,PHC,444,SubCentre,555,Village,,,9439986200


### PR DESCRIPTION
This implements an ops hook to consume NIC data from an http client with specific fields in a contract. This helps sync up one-time db dumps to make up for MCTS service availability (lack of)