### PR TITLE
Case id null bug fix

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
@@ -1,6 +1,7 @@
 package org.motechproject.nms.kilkari.service;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.motechproject.mds.annotations.InstanceLifecycleListener;
 import org.motechproject.mds.annotations.InstanceLifecycleListenerType;
 import org.motechproject.nms.kilkari.domain.MctsBeneficiary;
@@ -62,7 +63,7 @@ public interface SubscriberService {
      * @param lmp the reference date for the mother (last menstrual period)
      * @return New or updated subscription, null if the creation/update fails
      */
-    Subscription updateMotherSubscriber(Long msisdn, MctsMother mother, DateTime lmp, Map<String, Object> record, String action);
+    Subscription updateMotherSubscriber(Long msisdn, MctsMother mother, DateTime lmp, Map<String, Object> record, String action, String name,DateTime motherDOB,LocalDate lastUpdatedDateNic);
 
     /**
      * Update the RCH mother subscriber with the msisdn and mother object
@@ -73,7 +74,7 @@ public interface SubscriberService {
      * @param deactivate boolean to check if subscription needs to be deactivated due to abortion, stillbirth or death
      * @return New or updated subscription, null if the creation/update fails
      */
-    Subscription updateRchMotherSubscriber(Long msisdn, MctsMother mother, DateTime lmp, Long caseNo, Boolean deactivate, Map<String, Object> record, String action);
+    Subscription updateRchMotherSubscriber(Long msisdn, MctsMother mother, DateTime lmp, Long caseNo, Boolean deactivate, Map<String, Object> record, String action,String name,DateTime motherDOB,LocalDate lastUpdatedDateNic);
 
     /**
      * Update the child subscriber with the msisdn and child object

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -193,14 +193,13 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
            return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.UPDATED_RECORD_ALREADY_EXISTS, false);
         }
 
-        mother.setName(name);
-        mother.setDateOfBirth(motherDOB);
-        //mother.setLastMenstrualPeriod(lmp);
-        mother.setUpdatedDateNic(lastUpdatedDateNic);
         if (mother.getId() != null && mother.getLastMenstrualPeriod() == null) {
+            mother.setName(name);
+            mother.setDateOfBirth(motherDOB);
+            //mother.setLastMenstrualPeriod(lmp);
+            mother.setUpdatedDateNic(lastUpdatedDateNic);
             mctsMotherDataService.update(mother);
         }
-        mother.setLastMenstrualPeriod(lmp);
 
 
         // Check if existing subscription needs to be deactivated
@@ -234,7 +233,7 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.ACTIVE_CHILD_PRESENT, false);
                 }
-                subscription = subscriberService.updateMotherSubscriber(msisdn, mother, lmp, record, action);
+                subscription = subscriberService.updateMotherSubscriber(msisdn, mother, lmp, record, action,name,motherDOB,lastUpdatedDateNic);
                 if (subscription == null) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.MOBILE_NUMBER_ALREADY_SUBSCRIBED, false);
@@ -252,7 +251,7 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
                     return motherRejectionRch(convertMapToRchMother(record), false, RejectionReasons.INVALID_CASE_NO.toString(), action);
                 }
-                subscription = subscriberService.updateRchMotherSubscriber(msisdn, mother, lmp, caseNo, deactivate, record, action);
+                subscription = subscriberService.updateRchMotherSubscriber(msisdn, mother, lmp, caseNo, deactivate, record, action,name,motherDOB,lastUpdatedDateNic);
                 if (subscription == null) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.MOBILE_NUMBER_ALREADY_SUBSCRIBED, false);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -195,11 +195,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
         mother.setName(name);
         mother.setDateOfBirth(motherDOB);
-        mother.setLastMenstrualPeriod(lmp);
+        //mother.setLastMenstrualPeriod(lmp);
         mother.setUpdatedDateNic(lastUpdatedDateNic);
-        if (mother.getId() != null) {
+        if (mother.getId() != null && mother.getLastMenstrualPeriod() == null) {
             mctsMotherDataService.update(mother);
         }
+        mother.setLastMenstrualPeriod(lmp);
 
 
         // Check if existing subscription needs to be deactivated

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -180,6 +180,11 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
         // have 12 weeks left in the pack. For existing users, their lmp could be updated to
         // an earlier date if it's an complete mother record(i.e not created through child import)
         // validate and set location
+        if(mother.getId()==null){
+            mother.setName(name);
+            mother.setDateOfBirth(motherDOB);
+            mother.setUpdatedDateNic(lastUpdatedDateNic);
+        }
 
         try {
              mctsBeneficiaryValueProcessor.setLocationFieldsCSV(locationFinder, record, mother);
@@ -192,16 +197,6 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
         if (mother.getUpdatedDateNic() != null && (lastUpdatedDateNic == null || mother.getUpdatedDateNic().isAfter(lastUpdatedDateNic))) {
            return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.UPDATED_RECORD_ALREADY_EXISTS, false);
         }
-
-        if (mother.getId() != null && mother.getLastMenstrualPeriod() == null) {
-            mother.setName(name);
-            mother.setDateOfBirth(motherDOB);
-            //mother.setLastMenstrualPeriod(lmp);
-            mother.setUpdatedDateNic(lastUpdatedDateNic);
-            mctsMotherDataService.update(mother);
-        }
-
-
         // Check if existing subscription needs to be deactivated
         Boolean deactivate = ((abortion != null) && abortion) || ((stillBirth != null) && stillBirth) || ((death != null) && death);  // NO CHECKSTYLE Boolean Expression Complexity
         if (deactivate && (mother.getId() == null)) {
@@ -231,6 +226,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                 //validate if an ACTIVE child is already present for the mother. If yes, ignore the update
                 if (childAlreadyPresent(beneficiaryId, importOrigin)) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
+                    if (mother.getLastMenstrualPeriod() == null) {
+                        mother.setName(name);
+                        mother.setDateOfBirth(motherDOB);
+                        mother.setUpdatedDateNic(lastUpdatedDateNic);
+                        //mctsMotherDataService.update(mother);
+                    }
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.ACTIVE_CHILD_PRESENT, false);
                 }
                 subscription = subscriberService.updateMotherSubscriber(msisdn, mother, lmp, record, action,name,motherDOB,lastUpdatedDateNic);
@@ -242,6 +243,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 if (childAlreadyPresent(beneficiaryId, importOrigin)) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
+                    if (mother.getLastMenstrualPeriod() == null) {
+                        mother.setName(name);
+                        mother.setDateOfBirth(motherDOB);
+                        mother.setUpdatedDateNic(lastUpdatedDateNic);
+                        //mctsMotherDataService.update(mother);
+                    }
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.ACTIVE_CHILD_PRESENT, false);
                 }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -3,6 +3,7 @@ package org.motechproject.nms.kilkari.service.impl;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.datanucleus.store.rdbms.query.ForwardQueryResult;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.motechproject.mds.query.SqlQueryExecution;
 import org.motechproject.nms.kilkari.domain.RejectionReasons;
 import org.motechproject.nms.kilkari.domain.BlockedMsisdnRecord;
@@ -219,7 +220,7 @@ public class SubscriberServiceImpl implements SubscriberService {
     }
 
     @Override // NO CHECKSTYLE Cyclomatic Complexity
-    public Subscription updateMotherSubscriber(Long msisdn, MctsMother motherUpdate, DateTime lmp, Map<String, Object> record, String action) { //NOPMD NcssMethodCount
+    public Subscription updateMotherSubscriber(Long msisdn, MctsMother motherUpdate, DateTime lmp, Map<String, Object> record, String action,String name,DateTime motherDOB,LocalDate lastUpdatedDateNic) { //NOPMD NcssMethodCount
         District district = motherUpdate.getDistrict(); // district should never be null here since we validate upstream on setLocation
         Circle circle = district.getCircle();
         Language language = district.getLanguage();
@@ -250,6 +251,12 @@ public class SubscriberServiceImpl implements SubscriberService {
                                 subscriber.setLastMenstrualPeriod(lmp);
                                 subscriber.setMother(motherUpdate);
                                 subscriber.setModificationDate(DateTime.now());
+
+                                //change 1
+                                motherUpdate.setName(name);
+                                motherUpdate.setDateOfBirth(motherDOB);
+                                motherUpdate.setLastMenstrualPeriod(lmp);
+                                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                                 return updateOrCreateSubscription(subscriber, motherSubscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                             } else {
                                 // Both IVR mother and child exists. Create a new subscriber record for mother and set the same in existing motherSubscription
@@ -258,6 +265,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                                 subscriberByMctsId.setMother(motherUpdate);
                                 subscriberByMctsId = create(subscriberByMctsId);
                                 motherSubscription.setSubscriber(subscriberByMctsId);
+
+                                //change 2
+                                motherUpdate.setName(name);
+                                motherUpdate.setDateOfBirth(motherDOB);
+                                motherUpdate.setLastMenstrualPeriod(lmp);
+                                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+
                                 return updateOrCreateSubscription(subscriberByMctsId, motherSubscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                             }
                         }
@@ -273,6 +287,12 @@ public class SubscriberServiceImpl implements SubscriberService {
                 Subscription subscription = subscriptionService.getActiveSubscription(subscriberByMctsId, pack.getType());
                 subscriberByMctsId.setLastMenstrualPeriod(lmp);
                 subscriberByMctsId.setModificationDate(DateTime.now());
+
+                //change 3
+                motherUpdate.setName(name);
+                motherUpdate.setDateOfBirth(motherDOB);
+                motherUpdate.setLastMenstrualPeriod(lmp);
+                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 return updateOrCreateSubscription(subscriberByMctsId, subscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
             } else {    // we have a subscriber by phone# and also one with the MCTS id
                 for (Subscriber subscriber : subscriberByMsisdns) {
@@ -280,6 +300,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                         Subscription subscription = subscriptionService.getActiveSubscription(subscriberByMctsId, pack.getType());
                         subscriberByMctsId.setLastMenstrualPeriod(lmp);
                         subscriberByMctsId.setModificationDate(DateTime.now());
+
+
+                        //change 4
+                        motherUpdate.setName(name);
+                        motherUpdate.setDateOfBirth(motherDOB);
+                        motherUpdate.setLastMenstrualPeriod(lmp);
+                        motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                         return updateOrCreateSubscription(subscriberByMctsId, subscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                     }
                 }
@@ -290,7 +317,7 @@ public class SubscriberServiceImpl implements SubscriberService {
     }
 
     @Override // NO CHECKSTYLE Cyclomatic Complexity
-    public Subscription updateRchMotherSubscriber(Long msisdn, MctsMother motherUpdate, DateTime lmp, Long caseNo, Boolean deactivate, Map<String, Object> record, String action) { //NOPMD NcssMethodCount
+    public Subscription updateRchMotherSubscriber(Long msisdn, MctsMother motherUpdate, DateTime lmp, Long caseNo, Boolean deactivate, Map<String, Object> record, String action, String name,DateTime motherDOB,LocalDate lastUpdatedDateNic) { //NOPMD NcssMethodCount
         District district = motherUpdate.getDistrict(); // district should never be null here since we validate upstream on setLocation
         Circle circle = district.getCircle();
         Language language = district.getLanguage();
@@ -311,6 +338,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                 subscriberByMsisdn.setMother(motherUpdate);
                 subscriberByMsisdn.setCaseNo(caseNo);
                 motherUpdate.setMaxCaseNo(caseNo);
+
+                //change 1
+                motherUpdate.setName(name);
+                motherUpdate.setDateOfBirth(motherDOB);
+                motherUpdate.setLastMenstrualPeriod(lmp);
+                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+
                 create(subscriberByMsisdn);
                 return subscriptionService.createSubscription(subscriberByMsisdn, msisdn, language, circle, pack, SubscriptionOrigin.RCH_IMPORT);
             } else {  // subscriber (number) is already in use
@@ -323,6 +357,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByMsisdn.setMother(motherUpdate);
                     subscriberByMsisdn.setCaseNo(caseNo);
                     motherUpdate.setMaxCaseNo(caseNo);
+
+                    //change 2
+                    motherUpdate.setName(name);
+                    motherUpdate.setDateOfBirth(motherDOB);
+                    motherUpdate.setLastMenstrualPeriod(lmp);
+                    motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+
                     create(subscriberByMsisdn);
                     return subscriptionService.createSubscription(subscriberByMsisdn, msisdn, language, circle, pack, SubscriptionOrigin.RCH_IMPORT);
                 }
@@ -342,6 +383,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                 Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                 subscriberByRchId.setLastMenstrualPeriod(lmp);
                 subscriberByRchId.setModificationDate(DateTime.now());
+
+                //channge 3
+                motherUpdate.setName(name);
+                motherUpdate.setDateOfBirth(motherDOB);
+                motherUpdate.setLastMenstrualPeriod(lmp);
+                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 for (Subscriber subscriber : subscribersByMsisdn) {
@@ -349,6 +397,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                         Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                         motherUpdate.setMaxCaseNo(caseNo);
                         subscriberByRchId.setLastMenstrualPeriod(lmp);
+
+                        //change 4
+                        motherUpdate.setName(name);
+                        motherUpdate.setDateOfBirth(motherDOB);
+                        motherUpdate.setLastMenstrualPeriod(lmp);
+                        motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+
                         Boolean greaterCaseNo = false;
                         if (subscriberByRchId.getCaseNo() != null && caseNo > subscriberByRchId.getCaseNo()) {
                             greaterCaseNo = true;
@@ -368,6 +423,12 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByRchId.setCaseNo(caseNo);
                     motherUpdate.setMaxCaseNo(caseNo);
                     subscriberByRchId.setModificationDate(DateTime.now());
+
+                    //change 5
+                    motherUpdate.setName(name);
+                    motherUpdate.setDateOfBirth(motherDOB);
+                    motherUpdate.setLastMenstrualPeriod(lmp);
+                    motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                     return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                 }
             }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -248,29 +248,19 @@ public class SubscriberServiceImpl implements SubscriberService {
                             Subscription childSubscription = subscriptionService.getIVRSubscription(subscriptions, SubscriptionPackType.CHILD);
                             if (childSubscription == null) {
                                 //update the anonymous mother with MCTS details
+                                motherUpdate.setLastMenstrualPeriod(lmp);
                                 subscriber.setLastMenstrualPeriod(lmp);
                                 subscriber.setMother(motherUpdate);
                                 subscriber.setModificationDate(DateTime.now());
-
-                                //change 1
-                                motherUpdate.setName(name);
-                                motherUpdate.setDateOfBirth(motherDOB);
-                                motherUpdate.setLastMenstrualPeriod(lmp);
-                                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                                 return updateOrCreateSubscription(subscriber, motherSubscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                             } else {
                                 // Both IVR mother and child exists. Create a new subscriber record for mother and set the same in existing motherSubscription
                                 subscriberByMctsId = new Subscriber(msisdn, language);
                                 subscriberByMctsId.setLastMenstrualPeriod(lmp);
+                                motherUpdate.setLastMenstrualPeriod(lmp);
                                 subscriberByMctsId.setMother(motherUpdate);
                                 subscriberByMctsId = create(subscriberByMctsId);
                                 motherSubscription.setSubscriber(subscriberByMctsId);
-
-                                //change 2
-                                motherUpdate.setName(name);
-                                motherUpdate.setDateOfBirth(motherDOB);
-                                motherUpdate.setLastMenstrualPeriod(lmp);
-                                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
 
                                 return updateOrCreateSubscription(subscriberByMctsId, motherSubscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                             }
@@ -283,30 +273,26 @@ public class SubscriberServiceImpl implements SubscriberService {
             if (subscriberByMsisdns.isEmpty()) {   //no subscriber attached to the new number
                 // We got here because beneficiary's phone number changed
                 subscriptionService.deleteBlockedMsisdn(motherUpdate.getId(), subscriberByMctsId.getCallingNumber(), msisdn);
+                motherUpdate.setName(name);
+                motherUpdate.setDateOfBirth(motherDOB);
+                motherUpdate.setLastMenstrualPeriod(lmp);
+                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 subscriberByMctsId.setCallingNumber(msisdn);
                 Subscription subscription = subscriptionService.getActiveSubscription(subscriberByMctsId, pack.getType());
                 subscriberByMctsId.setLastMenstrualPeriod(lmp);
                 subscriberByMctsId.setModificationDate(DateTime.now());
 
-                //change 3
-                motherUpdate.setName(name);
-                motherUpdate.setDateOfBirth(motherDOB);
-                motherUpdate.setLastMenstrualPeriod(lmp);
-                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
                 return updateOrCreateSubscription(subscriberByMctsId, subscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
             } else {    // we have a subscriber by phone# and also one with the MCTS id
                 for (Subscriber subscriber : subscriberByMsisdns) {
                     if (subscriberByMctsId.getId().equals(subscriber.getId())) {
                         Subscription subscription = subscriptionService.getActiveSubscription(subscriberByMctsId, pack.getType());
-                        subscriberByMctsId.setLastMenstrualPeriod(lmp);
-                        subscriberByMctsId.setModificationDate(DateTime.now());
-
-
-                        //change 4
                         motherUpdate.setName(name);
                         motherUpdate.setDateOfBirth(motherDOB);
                         motherUpdate.setLastMenstrualPeriod(lmp);
                         motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+                        subscriberByMctsId.setLastMenstrualPeriod(lmp);
+                        subscriberByMctsId.setModificationDate(DateTime.now());
                         return updateOrCreateSubscription(subscriberByMctsId, subscription, lmp, pack, language, circle, SubscriptionOrigin.MCTS_IMPORT, false);
                     }
                 }
@@ -335,15 +321,10 @@ public class SubscriberServiceImpl implements SubscriberService {
                 // create subscriber, beneficiary, subscription and return
                 Subscriber subscriberByMsisdn = new Subscriber(msisdn, language);
                 subscriberByMsisdn.setLastMenstrualPeriod(lmp);
+                motherUpdate.setLastMenstrualPeriod(lmp);
                 subscriberByMsisdn.setMother(motherUpdate);
                 subscriberByMsisdn.setCaseNo(caseNo);
                 motherUpdate.setMaxCaseNo(caseNo);
-
-                //change 1
-                motherUpdate.setName(name);
-                motherUpdate.setDateOfBirth(motherDOB);
-                motherUpdate.setLastMenstrualPeriod(lmp);
-                motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
 
                 create(subscriberByMsisdn);
                 return subscriptionService.createSubscription(subscriberByMsisdn, msisdn, language, circle, pack, SubscriptionOrigin.RCH_IMPORT);
@@ -354,15 +335,10 @@ public class SubscriberServiceImpl implements SubscriberService {
                 } else {
                     Subscriber subscriberByMsisdn = new Subscriber(msisdn, language);
                     subscriberByMsisdn.setLastMenstrualPeriod(lmp);
+                    motherUpdate.setLastMenstrualPeriod(lmp);
                     subscriberByMsisdn.setMother(motherUpdate);
                     subscriberByMsisdn.setCaseNo(caseNo);
                     motherUpdate.setMaxCaseNo(caseNo);
-
-                    //change 2
-                    motherUpdate.setName(name);
-                    motherUpdate.setDateOfBirth(motherDOB);
-                    motherUpdate.setLastMenstrualPeriod(lmp);
-                    motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
 
                     create(subscriberByMsisdn);
                     return subscriptionService.createSubscription(subscriberByMsisdn, msisdn, language, circle, pack, SubscriptionOrigin.RCH_IMPORT);
@@ -383,8 +359,6 @@ public class SubscriberServiceImpl implements SubscriberService {
                 Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                 subscriberByRchId.setLastMenstrualPeriod(lmp);
                 subscriberByRchId.setModificationDate(DateTime.now());
-
-                //channge 3
                 motherUpdate.setName(name);
                 motherUpdate.setDateOfBirth(motherDOB);
                 motherUpdate.setLastMenstrualPeriod(lmp);
@@ -398,7 +372,6 @@ public class SubscriberServiceImpl implements SubscriberService {
                         motherUpdate.setMaxCaseNo(caseNo);
                         subscriberByRchId.setLastMenstrualPeriod(lmp);
 
-                        //change 4
                         motherUpdate.setName(name);
                         motherUpdate.setDateOfBirth(motherDOB);
                         motherUpdate.setLastMenstrualPeriod(lmp);
@@ -420,15 +393,14 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByRchId.setCallingNumber(msisdn);
                     Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                     subscriberByRchId.setLastMenstrualPeriod(lmp);
-                    subscriberByRchId.setCaseNo(caseNo);
-                    motherUpdate.setMaxCaseNo(caseNo);
-                    subscriberByRchId.setModificationDate(DateTime.now());
-
-                    //change 5
                     motherUpdate.setName(name);
                     motherUpdate.setDateOfBirth(motherDOB);
                     motherUpdate.setLastMenstrualPeriod(lmp);
                     motherUpdate.setUpdatedDateNic(lastUpdatedDateNic);
+                    subscriberByRchId.setCaseNo(caseNo);
+                    motherUpdate.setMaxCaseNo(caseNo);
+                    subscriberByRchId.setModificationDate(DateTime.now());
+
                     return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                 }
             }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -365,6 +365,8 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByRchId.setCallingNumber(msisdn);
                     Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                     subscriberByRchId.setLastMenstrualPeriod(lmp);
+                    subscriberByRchId.setCaseNo(caseNo);
+                    motherUpdate.setMaxCaseNo(caseNo);
                     subscriberByRchId.setModificationDate(DateTime.now());
                     return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                 }


### PR DESCRIPTION
Fixed a couple of bugs
1. CaseId was not being imported into the db in one case even though we were getting data in xml file.
2. Made changes to update mother and subscriber tables only if an update for a mother was accepted (previously, in a few cases, some fields in the mother table were being updated even if the record was rejected, leading to a mismatch in data between the mother and subscriber tables).