### PR TITLE
Multiple subscription issue fix

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -637,6 +637,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                         Subscription subscription = subscriptionService.getActiveSubscription(subscriber, pack.getType());
                         finalSubscription = updateOrCreateSubscription(subscriber, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                     } else {
+                        //this method is checking only with active child subscriber, to fix this we use boolean activeSubscriptionExists
 //                        if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.CHILD, motherRchId, childUpdate.getRchId())) {
                        if(activeSubscriptionExists){
                             return childRejectionRch(convertMapToRchChild(record), false, RejectionReasons.MOBILE_NUMBER_ALREADY_SUBSCRIBED.toString(), action);
@@ -658,6 +659,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                     create(subscriber);
                     finalSubscription = subscriptionService.createSubscription(subscriber, msisdn, language, pack, SubscriptionOrigin.RCH_IMPORT);
                 } else {
+                    //this method is checking only with active child subscriber, to fix this we use boolean activeSubscriptionExists
 //                    if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.CHILD, motherRchId, childUpdate.getRchId())) {
                       if(activeSubscriptionExists){
                         return childRejectionRch(convertMapToRchChild(record), false, RejectionReasons.MOBILE_NUMBER_ALREADY_SUBSCRIBED.toString(), action);


### PR DESCRIPTION
Step to reproduce scenario 1: 
1)import rch mother with case id=1(M1)
2)deactivate the mother ( I tried with reason "WEEKLY_CALLS_NOT_ANSWERED" and M"ISCARRIAGE_OR_ABORTION")(M1)
3)Import different mother with same mobile number and caseid=1(M2)
4)Import child(C2) for latest mother(M2)

Result=> both mother(M2) and child(C2) subscriber are in active status
Expected: M2 should be deactivated with reason LIVE_BIRTH and C2 in active status

	Step to reproduce scenario 2: 
1)import rch mother M1
2)Deactivate the mother ( I tried with reason "LOW_LISTENERSHIP" )
3)Import different mother with same mobile number M2
4)Import a child C0 with the same mobile number and mother registration no=null
5)Import child C2 for M2

Expected: C0 should be rejected with reason mobile number already subscribed and M2 should be deactivated with reason Live birth
Actual Result:  M2,C0,C2 are in ACTIVE status

Fix the above two scenarios