### PR TITLE
Data Integrity Error Fix

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -77,39 +77,35 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
             record.replace(id,newRchId);
-            //filter for rch child's MCTS_Mother_ID_No and mcts child's Mother_ID
+            //filter for rch child's MCTS_Mother_ID_No
 
             if(!mctsImport) {
                 //for rch child's mother registration no
                 try {
-                    LOGGER.debug("Mother Id---=>"+motherId);
-                    LOGGER.debug("record ----=>"+record);
                     String childLinkedMother=(String)record.get(motherId);
                     childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
                     record.replace(motherId,childLinkedMother);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mother for child");
+                    //LOGGER.debug("no mother for child");
                 }
                 //for rch child's MCTS_ID_No
                 try {
-                    LOGGER.debug("------in Mcts Id filter for rch child-----");
                     String newMctsId=(String)record.get(mctsIdForRchChild);
                     newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsIdForRchChild,newMctsId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts id for child");
+                    //LOGGER.debug("no mcts id for child");
                 }
                 // for rch child's MCTS_Mother_Id_N0
                 try{
-                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
                     String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
                     newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsMotherIdForChild,newMctsMotherId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts mother id for child");
+                    //LOGGER.debug("no mcts mother id for child");
                 }
             }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -72,7 +72,6 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
-            LOGGER.debug("---------mother record----------=>"+record);
             //filter for  rch mother's Registration_No and mcts mother's ID_no
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
@@ -80,13 +79,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             //for rch mother's MCTS_ID_No
             if(!mctsImport){
                 try {
-                    LOGGER.debug("------Mcts Id filter for rch mother-----");
                     String newMctsId=(String)record.get(mctsIDForRchMother);
                     newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsIDForRchMother,newMctsId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts id for the rch mother");
+                    //LOGGER.debug("no mcts id for the rch mother");
                 }
             }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -69,12 +69,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
-            if(record.get(id).toString().length()!=12){
-                //apply filter on rch id here
+            //apply filter on rch id here
+//            if(record.get(id).toString().length()!=12){
                 String newRchId=(String)record.get(id);
-                newRchId=newRchId.replaceAll("\n","");
+                newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
                 record.replace(id,newRchId);
-            }
+//            }
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {
                 MotherImportRejection motherImportRejection1 = motherRejectionRch(convertMapToRchMother(record), false, RejectionReasons.DATA_INTEGRITY_ERROR.toString(), KilkariConstants.CREATE);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -69,7 +69,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
-
+            if(record.get(id).toString().length()!=12){
+                //apply filter on rch id here
+                String newRchId=(String)record.get(id);
+                newRchId=newRchId.replaceAll("\n","");
+                record.replace(id,newRchId);
+            }
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {
                 MotherImportRejection motherImportRejection1 = motherRejectionRch(convertMapToRchMother(record), false, RejectionReasons.DATA_INTEGRITY_ERROR.toString(), KilkariConstants.CREATE);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -303,6 +303,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
+                    //removing special char from mcts child's mother_id
+                    String mctsMotherId=motherInstance.getBeneficiaryId();
+                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
+                    motherInstance.setBeneficiaryId(mctsMotherId);
+                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
+
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherInstance.getBeneficiaryId());
                 } catch (Exception e) {
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherRecord.toString());

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
@@ -84,7 +84,7 @@ public class MctsBeneficiaryValueProcessorImpl implements MctsBeneficiaryValuePr
                 return motherByRchId;
             } else {
                 motherByMctsId = mctsMotherDataService.findByBeneficiaryId(mctsId);
-                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "mcts null field update" issue
+                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "null mcts field update" issue
                     motherByRchId.setBeneficiaryId(mctsId);
                     return motherByRchId;
                 } else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
@@ -84,7 +84,7 @@ public class MctsBeneficiaryValueProcessorImpl implements MctsBeneficiaryValuePr
                 return motherByRchId;
             } else {
                 motherByMctsId = mctsMotherDataService.findByBeneficiaryId(mctsId);
-                if (motherByMctsId == null && motherByRchId.getBeneficiaryId() != null) {
+                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "mcts null field update" issue
                     motherByRchId.setBeneficiaryId(mctsId);
                     return motherByRchId;
                 } else {

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -320,6 +320,12 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             beneficiaryId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
+
+            // removing special char from beneficiary id
+            LOGGER.debug("filtring mcts mother beneficiary id in event");
+            beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
+            recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
+
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
             if(mother == null) {
@@ -493,6 +499,13 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             childId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
+
+            // removing special char from beneficiary id
+            LOGGER.debug("filtring child  beneficiary id and recors id--> "+recordMap);
+            childId=childId.replaceAll("[\\n\\t\\r ]","");
+            recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
+            LOGGER.debug("record map after filter on ids'--> "+recordMap);
+
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);
             recordMap.put(KilkariConstants.MCTS_CHILD, child);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -322,7 +322,6 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
 
             // removing special char from beneficiary id
-            LOGGER.debug("filtring mcts mother beneficiary id in event");
             beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
             recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
 
@@ -501,10 +500,8 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
 
             // removing special char from beneficiary id
-            LOGGER.debug("filtring child  beneficiary id and recors id--> "+recordMap);
             childId=childId.replaceAll("[\\n\\t\\r ]","");
             recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
-            LOGGER.debug("record map after filter on ids'--> "+recordMap);
 
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);


### PR DESCRIPTION
two root cause of data integrity are fixed in this branch
1)Scenario:
    creating a rch mother record with rch id r1 and mcts id=null
    update the mother record with rch id r1 and mcts id m1
   
    Expected result=> should update the mcts id in mother record
    Actual Result=> Reject the mother record with data integrity error
2)Scenario:
    import rch mother with rch_id r1+"\n"
    import rch mother with rch id r1
Whenever we receive update (without '\n') for records whose rchId incude"\n" at the end, we are treating update as a new subscriber 
-------------------------------------------------------------------FIX------------------------------------------------------------
**Issue**: The existing code allow line break(\n,\t,\r, white space) in the give ids(see the table) 
Eg:Import record 1 with above special char then import update for same record but this time id doesn't contain special char, In this scenario system treating this id as new Id but both ids are same in the term of numerical digits.

**After fix behavior of the system:** This fix will remove new Line('\n'), white space(' '), tab('\t'), '\r' form the given ids (table) before processing to DB,
Eg: if we import record with id="12 24\t5\n\t"
then system will save the record with id=12245


IMPORT Type               ID in Imported Record

RCH Mother                  Registration_no
                                      MCTS_ID_No

RCH Child                     Registration_no
                                      MCTS_ID_No
                                      Mother_Registration_no
                                      MCTS_Mother_ID_No

MCTS Mother               ID_No

MCTS Child                  ID_No
                                     Mother_ID




