### PR TITLE
Data integrity error fix Updated

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -6,6 +6,7 @@ import org.motechproject.nms.kilkari.domain.RejectionReasons;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.ThreadProcessorObject;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.region.domain.LocationFinder;
 import org.motechproject.nms.rejectionhandler.domain.ChildImportRejection;
 import org.slf4j.Logger;
@@ -80,10 +81,12 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(id);
-            listOfIds.add(motherId);
-            listOfIds.add(mctsIdForRchChild);
-            listOfIds.add(mctsMotherIdForChild);
-            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
+            if (!mctsImport) {
+                listOfIds.add(motherId);
+                listOfIds.add(mctsIdForRchChild);
+                listOfIds.add(mctsMotherIdForChild);
+            }
+            MctsBeneficiaryUtils.idCleanup(listOfIds,record);
 
             MctsChild child = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateChildInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchChildInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (child == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -83,8 +83,7 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
                 //for rch child's mother registration no
                 try {
                     String childLinkedMother=(String)record.get(motherId);
-                    childLinkedMother=childLinkedMother
-                            .replaceAll("[\\n\\t\\r ]","");
+                    childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
                     record.replace(motherId,childLinkedMother);
                 }
                 catch (Exception e){

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -73,17 +73,18 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             count++;
             LOGGER.debug("Started child import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
-            //filter for  rch child's Registration_No and mcts child's ID_no
+            //filter on  rch child's Registration_No and mcts child's ID_no
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
             record.replace(id,newRchId);
-            //filter for rch child's MCTS_Mother_ID_No
+            //filter on rch child's MCTS_Mother_ID_No and mcts child's Mother_ID
 
             if(!mctsImport) {
                 //for rch child's mother registration no
                 try {
                     String childLinkedMother=(String)record.get(motherId);
-                    childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
+                    childLinkedMother=childLinkedMother
+                            .replaceAll("[\\n\\t\\r ]","");
                     record.replace(motherId,childLinkedMother);
                 }
                 catch (Exception e){
@@ -100,6 +101,7 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
                 }
                 // for rch child's MCTS_Mother_Id_N0
                 try{
+                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
                     String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
                     newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsMotherIdForChild,newMctsMotherId);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -8,6 +8,7 @@ import org.motechproject.nms.rejectionhandler.domain.ChildImportRejection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,42 +74,55 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             count++;
             LOGGER.debug("Started child import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(id);
+            listOfIds.add(motherId);
+            listOfIds.add(mctsIdForRchChild);
+            listOfIds.add(mctsMotherIdForChild);
+            LOGGER.debug("-----------record before filter---------------------------------=>", record);
+            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
+
+            LOGGER.debug("------------------------record after filter-------------------=>", record);
+
+            LOGGER.debug("-----------------------id after filter-------------------------=>", record.get(id));
+
+
             //filter on  rch child's Registration_No and mcts child's ID_no
-            String newRchId=(String)record.get(id);
-            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
-            record.replace(id,newRchId);
+//            String newRchId=(String)record.get(id);
+//            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
+//            record.replace(id,newRchId);
             //filter on rch child's MCTS_Mother_ID_No
 
-            if(!mctsImport) {
-                //for rch child's mother registration no
-                try {
-                    String childLinkedMother=(String)record.get(motherId);
-                    childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
-                    record.replace(motherId,childLinkedMother);
-                }
-                catch (Exception e){
-                    //LOGGER.debug("no mother for child");
-                }
-                //for rch child's MCTS_ID_No
-                try {
-                    String newMctsId=(String)record.get(mctsIdForRchChild);
-                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
-                    record.replace(mctsIdForRchChild,newMctsId);
-                }
-                catch (Exception e){
-                    //LOGGER.debug("no mcts id for child");
-                }
-                // for rch child's MCTS_Mother_Id_N0
-                try{
-                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
-                    String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
-                    newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
-                    record.replace(mctsMotherIdForChild,newMctsMotherId);
-                }
-                catch (Exception e){
-                    //LOGGER.debug("no mcts mother id for child");
-                }
-            }
+//            if(!mctsImport) {
+//                //for rch child's mother registration no
+//                try {
+//                    String childLinkedMother=(String)record.get(motherId);
+//                    childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
+//                    record.replace(motherId,childLinkedMother);
+//                }
+//                catch (Exception e){
+//                    //LOGGER.debug("no mother for child");
+//                }
+//                //for rch child's MCTS_ID_No
+//                try {
+//                    String newMctsId=(String)record.get(mctsIdForRchChild);
+//                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
+//                    record.replace(mctsIdForRchChild,newMctsId);
+//                }
+//                catch (Exception e){
+//                    //LOGGER.debug("no mcts id for child");
+//                }
+//                // for rch child's MCTS_Mother_Id_N0
+//                try{
+//                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
+//                    String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
+//                    newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
+//                    record.replace(mctsMotherIdForChild,newMctsMotherId);
+//                }
+//                catch (Exception e){
+//                    //LOGGER.debug("no mcts mother id for child");
+//                }
+//            }
 
             MctsChild child = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateChildInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchChildInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (child == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -77,7 +77,7 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
             record.replace(id,newRchId);
-            //filter on rch child's MCTS_Mother_ID_No and mcts child's Mother_ID
+            //filter on rch child's MCTS_Mother_ID_No
 
             if(!mctsImport) {
                 //for rch child's mother registration no

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -1,7 +1,10 @@
 package org.motechproject.nms.kilkari.service;
 
 import org.motechproject.metrics.service.Timer;
-import org.motechproject.nms.kilkari.domain.*;
+import org.motechproject.nms.kilkari.domain.MctsChild;
+import org.motechproject.nms.kilkari.domain.RejectionReasons;
+import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
+import org.motechproject.nms.kilkari.domain.ThreadProcessorObject;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
 import org.motechproject.nms.region.domain.LocationFinder;
 import org.motechproject.nms.rejectionhandler.domain.ChildImportRejection;

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -77,39 +77,35 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
             record.replace(id,newRchId);
-            //filter for rch child's MCTS_Mother_ID_No and mcts child's Mother_ID
+            //filter for rch child's MCTS_Mother_ID_No
 
             if(!mctsImport) {
                 //for rch child's mother registration no
                 try {
-                    LOGGER.debug("Mother Id---=>"+motherId);
-                    LOGGER.debug("record ----=>"+record);
                     String childLinkedMother=(String)record.get(motherId);
                     childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
                     record.replace(motherId,childLinkedMother);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mother for child");
+                    //LOGGER.debug("no mother for child");
                 }
                 //for rch child's MCTS_ID_No
                 try {
-                    LOGGER.debug("------in Mcts Id filter for rch child-----");
                     String newMctsId=(String)record.get(mctsIdForRchChild);
                     newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsIdForRchChild,newMctsId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts id for child");
+                    //LOGGER.debug("no mcts id for child");
                 }
                 // for rch child's MCTS_Mother_Id_N0
                 try{
-                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
                     String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
                     newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsMotherIdForChild,newMctsMotherId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts mother id for child");
+                    //LOGGER.debug("no mcts mother id for child");
                 }
             }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -79,50 +79,12 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             listOfIds.add(motherId);
             listOfIds.add(mctsIdForRchChild);
             listOfIds.add(mctsMotherIdForChild);
-            LOGGER.debug("-----------record before filter---------------------------------=>", record);
+            LOGGER.debug("-----------record before filter---------------------------------=>", record.toString());
             mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
 
-            LOGGER.debug("------------------------record after filter-------------------=>", record);
+            LOGGER.debug("------------------------record after filter-------------------=>", record.toString());
 
             LOGGER.debug("-----------------------id after filter-------------------------=>", record.get(id));
-
-
-            //filter on  rch child's Registration_No and mcts child's ID_no
-//            String newRchId=(String)record.get(id);
-//            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
-//            record.replace(id,newRchId);
-            //filter on rch child's MCTS_Mother_ID_No
-
-//            if(!mctsImport) {
-//                //for rch child's mother registration no
-//                try {
-//                    String childLinkedMother=(String)record.get(motherId);
-//                    childLinkedMother=childLinkedMother.replaceAll("[\\n\\t\\r ]","");
-//                    record.replace(motherId,childLinkedMother);
-//                }
-//                catch (Exception e){
-//                    //LOGGER.debug("no mother for child");
-//                }
-//                //for rch child's MCTS_ID_No
-//                try {
-//                    String newMctsId=(String)record.get(mctsIdForRchChild);
-//                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
-//                    record.replace(mctsIdForRchChild,newMctsId);
-//                }
-//                catch (Exception e){
-//                    //LOGGER.debug("no mcts id for child");
-//                }
-//                // for rch child's MCTS_Mother_Id_N0
-//                try{
-//                    LOGGER.debug("------Mcts mother Id filter for rch child-----");
-//                    String newMctsMotherId=(String)record.get(mctsMotherIdForChild);
-//                    newMctsMotherId=newMctsMotherId.replaceAll("[\\n\\t\\r ]","");
-//                    record.replace(mctsMotherIdForChild,newMctsMotherId);
-//                }
-//                catch (Exception e){
-//                    //LOGGER.debug("no mcts mother id for child");
-//                }
-//            }
 
             MctsChild child = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateChildInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchChildInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (child == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -74,17 +74,13 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
             count++;
             LOGGER.debug("Started child import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
+            //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(id);
             listOfIds.add(motherId);
             listOfIds.add(mctsIdForRchChild);
             listOfIds.add(mctsMotherIdForChild);
-            LOGGER.debug("-----------record before filter---------------------------------=>", record.toString());
             mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
-
-            LOGGER.debug("------------------------record after filter-------------------=>", record.toString());
-
-            LOGGER.debug("-----------------------id after filter-------------------------=>", record.get(id));
 
             MctsChild child = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateChildInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchChildInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (child == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
@@ -38,5 +38,4 @@ public interface MctsBeneficiaryImportService {
     Map<String, CellProcessor> getRchMotherProcessorMapping();
 
     Map<String, CellProcessor> getRchAshaProcessorMapping();
-    void removeSpecialChar(ArrayList<String > listOfIds, Map<String, Object> record);
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
@@ -9,6 +9,7 @@ import org.motechproject.nms.rejectionhandler.domain.MotherImportRejection;
 import org.springframework.transaction.annotation.Transactional;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -37,4 +38,5 @@ public interface MctsBeneficiaryImportService {
     Map<String, CellProcessor> getRchMotherProcessorMapping();
 
     Map<String, CellProcessor> getRchAshaProcessorMapping();
-}
+    public void removeSpecialChar(ArrayList<String > listOfIds, Map<String, Object> record);
+    }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MctsBeneficiaryImportService.java
@@ -38,5 +38,5 @@ public interface MctsBeneficiaryImportService {
     Map<String, CellProcessor> getRchMotherProcessorMapping();
 
     Map<String, CellProcessor> getRchAshaProcessorMapping();
-    public void removeSpecialChar(ArrayList<String > listOfIds, Map<String, Object> record);
+    void removeSpecialChar(ArrayList<String > listOfIds, Map<String, Object> record);
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -72,7 +72,6 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
-            LOGGER.debug("---------mother record----------=>"+record);
             //filter for  rch mother's Registration_No and mcts mother's ID_no
             String newRchId=(String)record.get(id);
             newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
@@ -80,13 +79,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             //for rch mother's MCTS_ID_No
             if(!mctsImport){
                 try {
-                    LOGGER.debug("------Mcts Id filter for rch mother-----");
                     String newMctsId=(String)record.get(mctsIDForRchMother);
                     newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
                     record.replace(mctsIDForRchMother,newMctsId);
                 }
                 catch (Exception e){
-                    LOGGER.debug("no mcts id for the rch mother");
+                    //LOGGER.debug("no mcts id for the rch mother");
                 }
             }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -6,6 +6,7 @@ import org.motechproject.nms.kilkari.domain.RejectionReasons;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.ThreadProcessorObject;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.region.domain.LocationFinder;
 import org.motechproject.nms.rejectionhandler.domain.MotherImportRejection;
 import org.slf4j.Logger;
@@ -75,8 +76,10 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(id);
-            listOfIds.add(mctsIDForRchMother);
-            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
+            if (!mctsImport) {
+                listOfIds.add(mctsIDForRchMother);
+            }
+            MctsBeneficiaryUtils.idCleanup(listOfIds,record);
 
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -73,20 +73,20 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
             //filter for  rch mother's Registration_No and mcts mother's ID_no
-            String newRchId=(String)record.get(id);
-            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
-            record.replace(id,newRchId);
+//            String newRchId=(String)record.get(id);
+//            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
+//            record.replace(id,newRchId);
             //for rch mother's MCTS_ID_No
-            if(!mctsImport){
-                try {
-                    String newMctsId=(String)record.get(mctsIDForRchMother);
-                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
-                    record.replace(mctsIDForRchMother,newMctsId);
-                }
-                catch (Exception e){
-                    //LOGGER.debug("no mcts id for the rch mother");
-                }
-            }
+//            if(!mctsImport){
+//                try {
+//                    String newMctsId=(String)record.get(mctsIDForRchMother);
+//                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
+//                    record.replace(mctsIDForRchMother,newMctsId);
+//                }
+//                catch (Exception e){
+//                    //LOGGER.debug("no mcts id for the rch mother");
+//                }
+//            }
 
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -11,6 +11,7 @@ import org.motechproject.nms.rejectionhandler.domain.MotherImportRejection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,21 +73,17 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
 
-            //filter for  rch mother's Registration_No and mcts mother's ID_no
-//            String newRchId=(String)record.get(id);
-//            newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
-//            record.replace(id,newRchId);
-            //for rch mother's MCTS_ID_No
-//            if(!mctsImport){
-//                try {
-//                    String newMctsId=(String)record.get(mctsIDForRchMother);
-//                    newMctsId=newMctsId.replaceAll("[\\n\\t\\r ]","");
-//                    record.replace(mctsIDForRchMother,newMctsId);
-//                }
-//                catch (Exception e){
-//                    //LOGGER.debug("no mcts id for the rch mother");
-//                }
-//            }
+
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(id);
+            listOfIds.add(mctsIDForRchMother);
+
+            LOGGER.debug("-----------record before filter---------------------------------=>", record.toString());
+            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
+
+            LOGGER.debug("------------------------record after filter-------------------=>", record.toString());
+
+            LOGGER.debug("-----------------------id after filter-------------------------=>", record.get(id));
 
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -69,12 +69,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
-            if(record.get(id).toString().length()!=12){
-                //apply filter on rch id here
+            //apply filter on rch id here
+//            if(record.get(id).toString().length()!=12){
                 String newRchId=(String)record.get(id);
-                newRchId=newRchId.replaceAll("\n","");
+                newRchId=newRchId.replaceAll("[\\n\\t\\r ]","");
                 record.replace(id,newRchId);
-            }
+//            }
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {
                 MotherImportRejection motherImportRejection1 = motherRejectionRch(convertMapToRchMother(record), false, RejectionReasons.DATA_INTEGRITY_ERROR.toString(), KilkariConstants.CREATE);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -69,7 +69,12 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
-
+            if(record.get(id).toString().length()!=12){
+                //apply filter on rch id here
+                String newRchId=(String)record.get(id);
+                newRchId=newRchId.replaceAll("\n","");
+                record.replace(id,newRchId);
+            }
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {
                 MotherImportRejection motherImportRejection1 = motherRejectionRch(convertMapToRchMother(record), false, RejectionReasons.DATA_INTEGRITY_ERROR.toString(), KilkariConstants.CREATE);

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -72,18 +72,11 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
-
-
+            //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(id);
             listOfIds.add(mctsIDForRchMother);
-
-            LOGGER.debug("-----------record before filter---------------------------------=>", record.toString());
             mctsBeneficiaryImportService.removeSpecialChar(listOfIds,record);
-
-            LOGGER.debug("------------------------record after filter-------------------=>", record.toString());
-
-            LOGGER.debug("-----------------------id after filter-------------------------=>", record.get(id));
 
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -303,6 +303,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
+                    //removing special char from mcts child's mother_id
+                    String mctsMotherId=motherInstance.getBeneficiaryId();
+                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
+                    motherInstance.setBeneficiaryId(mctsMotherId);
+                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
+
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherInstance.getBeneficiaryId());
                 } catch (Exception e) {
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherRecord.toString());

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -304,10 +304,10 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
                     //removing special char from mcts child's mother_id
-                    String mctsMotherId=motherInstance.getBeneficiaryId();
-                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
-                    motherInstance.setBeneficiaryId(mctsMotherId);
-                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
+//                    String mctsMotherId=motherInstance.getBeneficiaryId();
+//                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
+//                    motherInstance.setBeneficiaryId(mctsMotherId);
+//                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
 
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherInstance.getBeneficiaryId());
                 } catch (Exception e) {
@@ -983,8 +983,22 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
         return mapping;
     }
+    public void removeSpecialChar(ArrayList<String > listOfIds,Map<String, Object> record){
+
+        for(String id :listOfIds){
+            try{
+                String idValue=(String)record.get(id);
+                idValue=idValue.replaceAll("[\\n\\t\\r ]","");
+                record.replace(id,idValue);
+                LOGGER.debug("-----------------method called and filtered the record-------------------=>", record);
+
+            }
+            catch (Exception e){
+                continue;
+            }
+        }
 
 
-
+    }
 
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -303,7 +303,7 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
-                    //removing special char from mcts child's mother_id
+                    //changes made to remove special character form the mcts child's mother_id
                     String mctsMotherId=motherInstance.getBeneficiaryId();
                     mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
                     motherInstance.setBeneficiaryId(mctsMotherId);
@@ -990,8 +990,6 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                 String idValue=(String)record.get(id);
                 idValue=idValue.replaceAll("[\\n\\t\\r ]","");
                 record.replace(id,idValue);
-                LOGGER.debug("-----------------method called and filtered the record-------------------=>", record);
-
             }
             catch (Exception e){
                 continue;

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -305,7 +305,12 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                     MctsMother motherInstance = (MctsMother) motherRecord;
                     //changes made to remove special character form the mcts child's mother_id
                     String mctsMotherId=motherInstance.getBeneficiaryId();
-                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
+                    ArrayList<String > listOfIds=new ArrayList<>();
+                    listOfIds.add("ID_No");
+                    Map<String, Object> motherRecordTemp= new HashMap<>();;
+                    motherRecordTemp.put("ID_No",mctsMotherId);
+                    MctsBeneficiaryUtils.idCleanup(listOfIds,motherRecordTemp);
+                    mctsMotherId=(String)motherRecordTemp.get("ID_No");
                     motherInstance.setBeneficiaryId(mctsMotherId);
                     record.replace(KilkariConstants.MOTHER_ID,motherInstance);
 
@@ -982,21 +987,6 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
         mapping.put(FlwConstants.GF_STATUS, new Optional(new GetString()));
 
         return mapping;
-    }
-    public void removeSpecialChar(ArrayList<String > listOfIds,Map<String, Object> record){
-
-        for(String id :listOfIds){
-            try{
-                String idValue=(String)record.get(id);
-                idValue=idValue.replaceAll("[\\n\\t\\r ]","");
-                record.replace(id,idValue);
-            }
-            catch (Exception e){
-                continue;
-            }
-        }
-
-
     }
 
 }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -304,10 +304,10 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
                     //removing special char from mcts child's mother_id
-//                    String mctsMotherId=motherInstance.getBeneficiaryId();
-//                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
-//                    motherInstance.setBeneficiaryId(mctsMotherId);
-//                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
+                    String mctsMotherId=motherInstance.getBeneficiaryId();
+                    mctsMotherId=mctsMotherId.replaceAll("[\\n\\t\\r ]","");
+                    motherInstance.setBeneficiaryId(mctsMotherId);
+                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
 
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherInstance.getBeneficiaryId());
                 } catch (Exception e) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
@@ -84,7 +84,7 @@ public class MctsBeneficiaryValueProcessorImpl implements MctsBeneficiaryValuePr
                 return motherByRchId;
             } else {
                 motherByMctsId = mctsMotherDataService.findByBeneficiaryId(mctsId);
-                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "mcts null field update" issue
+                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "null mcts field update" issue
                     motherByRchId.setBeneficiaryId(mctsId);
                     return motherByRchId;
                 } else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
@@ -84,7 +84,7 @@ public class MctsBeneficiaryValueProcessorImpl implements MctsBeneficiaryValuePr
                 return motherByRchId;
             } else {
                 motherByMctsId = mctsMotherDataService.findByBeneficiaryId(mctsId);
-                if (motherByMctsId == null && motherByRchId.getBeneficiaryId() != null) {
+                if (motherByMctsId == null) { // removed the condition motherByRchId.getBeneficiaryId() != null to fix "mcts null field update" issue
                     motherByRchId.setBeneficiaryId(mctsId);
                     return motherByRchId;
                 } else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/KilkariConstants.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/KilkariConstants.java
@@ -131,6 +131,7 @@ public final class KilkariConstants {
     public static final String SUBSCRIPTION_CAP = "kilkari.subscription.cap";
     public static final String SUBSCRIPTION_MANAGER_CRON = "kilkari.subscription.manager.cron";
     public static final String ACCEPT_NEW_SUBSCRIPTION_FOR_BLOCKED_MSISDN = "kilkari.accept_new_subscription_for_blocked_msisdn";
+    public static final String SPECIAL_CHAR_STRING="[\\n\\t\\r ]";
 
 
     private KilkariConstants() {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/MctsBeneficiaryUtils.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/MctsBeneficiaryUtils.java
@@ -20,6 +20,7 @@ import org.supercsv.cellprocessor.Optional;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 
 import javax.validation.ConstraintViolation;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
@@ -91,4 +92,13 @@ public final class MctsBeneficiaryUtils {
         }
     }
 
+    public static void idCleanup(ArrayList<String > listOfIds, Map<String, Object> record){
+        for(String id :listOfIds){
+            if(record.get(id)!=null){
+                String idValue=(String)record.get(id);
+                idValue=idValue.replaceAll(KilkariConstants.SPECIAL_CHAR_STRING,"");
+                record.replace(id,idValue);
+            }
+        }
+    }
 }

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -28,6 +28,7 @@ import org.motechproject.nms.flwUpdate.service.FrontLineWorkerImportService;
 import org.motechproject.nms.kilkari.service.MctsBeneficiaryImportService;
 import org.motechproject.nms.kilkari.service.MctsBeneficiaryValueProcessor;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.mcts.contract.AnmAshaDataSet;
 import org.motechproject.nms.kilkari.contract.AnmAshaRecord;
 import org.motechproject.nms.kilkari.contract.ChildRecord;
@@ -324,7 +325,7 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(KilkariConstants.BENEFICIARY_ID);
-            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
+            MctsBeneficiaryUtils.idCleanup(listOfIds,recordMap);
 
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
@@ -503,8 +504,7 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(KilkariConstants.BENEFICIARY_ID);
-            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
-
+            MctsBeneficiaryUtils.idCleanup(listOfIds,recordMap);
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);
             recordMap.put(KilkariConstants.MCTS_CHILD, child);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -321,10 +321,14 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
 
-            // removing special char from beneficiary id
-//            LOGGER.debug("filtring mcts mother beneficiary id in event");
-//            beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
-//            recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(KilkariConstants.BENEFICIARY_ID);
+            LOGGER.debug("-----------record before filter---------------------------------=>", recordMap.toString());
+
+            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
+
+            LOGGER.debug("------------------------record after filter-------------------=>", recordMap.toString());
+            LOGGER.debug("-----------------------id after filter-------------------------=>", recordMap.get(KilkariConstants.BENEFICIARY_ID));
 
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
@@ -500,9 +504,15 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
 
-            // removing special char from beneficiary id
-//            childId=childId.replaceAll("[\\n\\t\\r ]","");
-//            recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(KilkariConstants.BENEFICIARY_ID);
+            LOGGER.debug("-----------record before filter---------------------------------=>", recordMap.toString());
+
+            mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
+
+            LOGGER.debug("------------------------record after filter-------------------=>", recordMap.toString());
+            LOGGER.debug("-----------------------id after filter-------------------------=>", recordMap.get(KilkariConstants.BENEFICIARY_ID));
+
 
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -320,6 +320,12 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             beneficiaryId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
+
+            // removing special char from beneficiary id
+            LOGGER.debug("filtring mcts mother beneficiary id in event");
+            beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
+            recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
+
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
             if(mother == null) {
@@ -493,6 +499,13 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             childId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
+
+            // removing special char from beneficiary id
+            LOGGER.debug("filtring child  beneficiary id and recors id--> "+recordMap);
+            childId=childId.replaceAll("[\\n\\t\\r ]","");
+            recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
+            LOGGER.debug("record map after filter on ids'--> "+recordMap);
+
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);
             recordMap.put(KilkariConstants.MCTS_CHILD, child);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -322,7 +322,6 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
 
             // removing special char from beneficiary id
-            LOGGER.debug("filtring mcts mother beneficiary id in event");
             beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
             recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
 
@@ -501,10 +500,8 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
 
             // removing special char from beneficiary id
-            LOGGER.debug("filtring child  beneficiary id and recors id--> "+recordMap);
             childId=childId.replaceAll("[\\n\\t\\r ]","");
             recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
-            LOGGER.debug("record map after filter on ids'--> "+recordMap);
 
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -322,8 +322,9 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
 
             // removing special char from beneficiary id
-            beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
-            recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
+//            LOGGER.debug("filtring mcts mother beneficiary id in event");
+//            beneficiaryId=beneficiaryId.replaceAll("[\\n\\t\\r ]","");
+//            recordMap.replace(KilkariConstants.BENEFICIARY_ID,beneficiaryId);
 
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
@@ -500,8 +501,8 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
 
             // removing special char from beneficiary id
-            childId=childId.replaceAll("[\\n\\t\\r ]","");
-            recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
+//            childId=childId.replaceAll("[\\n\\t\\r ]","");
+//            recordMap.replace(KilkariConstants.BENEFICIARY_ID,childId);
 
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -321,14 +321,10 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
 
+            //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(KilkariConstants.BENEFICIARY_ID);
-            LOGGER.debug("-----------record before filter---------------------------------=>", recordMap.toString());
-
             mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
-
-            LOGGER.debug("------------------------record after filter-------------------=>", recordMap.toString());
-            LOGGER.debug("-----------------------id after filter-------------------------=>", recordMap.get(KilkariConstants.BENEFICIARY_ID));
 
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
@@ -504,15 +500,10 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
 
+            //changes made to remove special character form the listofids
             ArrayList<String > listOfIds=new ArrayList<>();
             listOfIds.add(KilkariConstants.BENEFICIARY_ID);
-            LOGGER.debug("-----------record before filter---------------------------------=>", recordMap.toString());
-
             mctsBeneficiaryImportService.removeSpecialChar(listOfIds,recordMap);
-
-            LOGGER.debug("------------------------record after filter-------------------=>", recordMap.toString());
-            LOGGER.debug("-----------------------id after filter-------------------------=>", recordMap.get(KilkariConstants.BENEFICIARY_ID));
-
 
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);


### PR DESCRIPTION
two root cause of data integrity are fixed in this branch
1)Scenario:
creating a rch mother record with rch id r1 and mcts id=null
update the mother record with rch id r1 and mcts id m1

Expected result=> should update the mcts id in mother record
Actual Result=> Reject the mother record with data integrity error
2)Scenario:
import rch mother with rch_id r1+"\n"
import rch mother with rch id r1
Whenever we receive update (without '\n') for records whose rchId incude"\n" at the end, we are treating update as a new subscriber
-------------------------------------------------------------------FIX------------------------------------------------------------
Issue: The existing code allow line break(\n,\t,\r, white space) in the give ids(see the table)
Eg:Import record 1 with above special char then import update for same record but this time id doesn't contain special char, In this scenario system treating this id as new Id but both ids are same in the term of numerical digits.

After fix behavior of the system: This fix will remove new Line('\n'), white space(' '), tab('\t'), '\r' form the given ids (table) before processing to DB,
Eg: if we import record with id="12 24\t5\n\t"
then system will save the record with id=12245

IMPORT Type ID in Imported Record

RCH Mother 
{Registration_no, MCTS_ID_No}

RCH Child 
{ Registration_no, MCTS_ID_No, Mother_Registration_no, MCTS_Mother_ID_No }

MCTS Mother { ID_No }

MCTS Child { ID_No, Mother_ID}