### PR TITLE
Data Integrity error fix and id cleanup

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/ChildCsvThreadProcessor.java
@@ -6,11 +6,13 @@ import org.motechproject.nms.kilkari.domain.RejectionReasons;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.ThreadProcessorObject;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.region.domain.LocationFinder;
 import org.motechproject.nms.rejectionhandler.domain.ChildImportRejection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,20 +56,37 @@ import static org.motechproject.nms.kilkari.utils.RejectedObjectConverter.conver
         String id;
         String contactNumber;
         String childInstance;
+        String mctsIdForRchChild=null;
+        String motherId;
+        String mctsMotherIdForChild=null;
         if (mctsImport) {
             id = KilkariConstants.BENEFICIARY_ID;
             contactNumber = KilkariConstants.MSISDN;
             childInstance = KilkariConstants.MCTS_CHILD;
+            motherId=KilkariConstants.MOTHER_ID;
         } else {
             id = KilkariConstants.RCH_ID;
             contactNumber = KilkariConstants.MOBILE_NO;
             childInstance = KilkariConstants.RCH_CHILD;
+            mctsIdForRchChild=KilkariConstants.MCTS_ID;
+            motherId=KilkariConstants.RCH_MOTHER_ID;
+            mctsMotherIdForChild=KilkariConstants.MCTS_MOTHER_ID;
         }
         int count = 0;
         Timer timer = new Timer("kid", "kids");
         for(Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started child import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
+
+            //changes made to remove special character form the listofids
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(id);
+            if (!mctsImport) {
+                listOfIds.add(motherId);
+                listOfIds.add(mctsIdForRchChild);
+                listOfIds.add(mctsMotherIdForChild);
+            }
+            MctsBeneficiaryUtils.idCleanup(listOfIds,record);
 
             MctsChild child = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateChildInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchChildInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (child == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/MotherCsvThreadProcessor.java
@@ -6,11 +6,13 @@ import org.motechproject.nms.kilkari.domain.RejectionReasons;
 import org.motechproject.nms.kilkari.domain.SubscriptionOrigin;
 import org.motechproject.nms.kilkari.domain.ThreadProcessorObject;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.region.domain.LocationFinder;
 import org.motechproject.nms.rejectionhandler.domain.MotherImportRejection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +57,7 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
         String id;
         String contactNumber;
         String motherInstance;
+        String mctsIDForRchMother=null;
         if (mctsImport) {
             id = KilkariConstants.BENEFICIARY_ID;
             contactNumber = KilkariConstants.MSISDN;
@@ -63,12 +66,21 @@ public class MotherCsvThreadProcessor implements Callable<ThreadProcessorObject>
             id = KilkariConstants.RCH_ID;
             contactNumber = KilkariConstants.MOBILE_NO;
             motherInstance = KilkariConstants.RCH_MOTHER;
+            mctsIDForRchMother = KilkariConstants.MCTS_ID;
         }
         int count = 0;
         Timer timer = new Timer("mom", "moms");
         for (Map<String, Object> record : recordList) {
             count++;
             LOGGER.debug("Started mother import for msisdn {} beneficiary_id {}", record.get(contactNumber), record.get(id));
+
+            //changes made to remove special character form the listofids
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(id);
+            if (!mctsImport) {
+                listOfIds.add(mctsIDForRchMother);
+            }
+            MctsBeneficiaryUtils.idCleanup(listOfIds,record);
 
             MctsMother mother = mctsImport ? mctsBeneficiaryValueProcessor.getOrCreateMotherInstance((String) record.get(id)) : mctsBeneficiaryValueProcessor.getOrCreateRchMotherInstance((String) record.get(id), (String) record.get(KilkariConstants.MCTS_ID));
             if (mother == null) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -338,6 +338,17 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 try {
                     MctsMother motherInstance = (MctsMother) motherRecord;
+
+                    String mctsMotherId=motherInstance.getBeneficiaryId();
+                    ArrayList<String > listOfIds=new ArrayList<>();
+                    listOfIds.add("ID_No");
+                    Map<String, Object> motherRecordTemp= new HashMap<>();;
+                    motherRecordTemp.put("ID_No",mctsMotherId);
+                    MctsBeneficiaryUtils.idCleanup(listOfIds,motherRecordTemp);
+                    mctsMotherId=(String)motherRecordTemp.get("ID_No");
+                    motherInstance.setBeneficiaryId(mctsMotherId);
+                    record.replace(KilkariConstants.MOTHER_ID,motherInstance);
+
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherInstance.getBeneficiaryId());
                 } catch (Exception e) {
                     mother = mctsBeneficiaryValueProcessor.getMotherInstanceByBeneficiaryId(motherRecord.toString());

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryValueProcessorImpl.java
@@ -84,7 +84,7 @@ public class MctsBeneficiaryValueProcessorImpl implements MctsBeneficiaryValuePr
                 return motherByRchId;
             } else {
                 motherByMctsId = mctsMotherDataService.findByBeneficiaryId(mctsId);
-                if (motherByMctsId == null && motherByRchId.getBeneficiaryId() != null) {
+                if (motherByMctsId == null) {// removed the condition motherByRchId.getBeneficiaryId() != null to fix "null mcts field update" issue
                     motherByRchId.setBeneficiaryId(mctsId);
                     return motherByRchId;
                 } else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/KilkariConstants.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/KilkariConstants.java
@@ -131,7 +131,7 @@ public final class KilkariConstants {
     public static final String SUBSCRIPTION_CAP = "kilkari.subscription.cap";
     public static final String SUBSCRIPTION_MANAGER_CRON = "kilkari.subscription.manager.cron";
     public static final String ACCEPT_NEW_SUBSCRIPTION_FOR_BLOCKED_MSISDN = "kilkari.accept_new_subscription_for_blocked_msisdn";
-
+    public static final String SPECIAL_CHAR_STRING="[\\n\\t\\r ]";
 
     private KilkariConstants() {
     }

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/MctsBeneficiaryUtils.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/utils/MctsBeneficiaryUtils.java
@@ -20,6 +20,7 @@ import org.supercsv.cellprocessor.Optional;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 
 import javax.validation.ConstraintViolation;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
@@ -90,5 +91,13 @@ public final class MctsBeneficiaryUtils {
             throw new CsvImportDataException(String.format(message, args));
         }
     }
-
+    public static void idCleanup(ArrayList<String > listOfIds, Map<String, Object> record){
+        for(String id :listOfIds){
+            if(record.get(id)!=null){
+                String idValue=(String)record.get(id);
+                idValue=idValue.replaceAll(KilkariConstants.SPECIAL_CHAR_STRING,"");
+                record.replace(id,idValue);
+            }
+        }
+    }
 }

--- a/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
+++ b/mcts/src/main/java/org/motechproject/nms/mcts/service/impl/MctsWsImportServiceImpl.java
@@ -28,6 +28,7 @@ import org.motechproject.nms.flwUpdate.service.FrontLineWorkerImportService;
 import org.motechproject.nms.kilkari.service.MctsBeneficiaryImportService;
 import org.motechproject.nms.kilkari.service.MctsBeneficiaryValueProcessor;
 import org.motechproject.nms.kilkari.utils.KilkariConstants;
+import org.motechproject.nms.kilkari.utils.MctsBeneficiaryUtils;
 import org.motechproject.nms.mcts.contract.AnmAshaDataSet;
 import org.motechproject.nms.kilkari.contract.AnmAshaRecord;
 import org.motechproject.nms.kilkari.contract.ChildRecord;
@@ -321,6 +322,12 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             beneficiaryId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime lmp = (DateTime) recordMap.get(KilkariConstants.LMP);
+
+            //changes made to remove special character form the listofids
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(KilkariConstants.BENEFICIARY_ID);
+            MctsBeneficiaryUtils.idCleanup(listOfIds,recordMap);
+
             mother = mctsBeneficiaryValueProcessor.getOrCreateMotherInstance(beneficiaryId);
             recordMap.put(KilkariConstants.MCTS_MOTHER, mother);
             if(mother == null) {
@@ -495,6 +502,12 @@ public class MctsWsImportServiceImpl implements MctsWsImportService {
             childId = (String) recordMap.get(KilkariConstants.BENEFICIARY_ID);
             msisdn = (Long) recordMap.get(KilkariConstants.MSISDN);
             DateTime dob = (DateTime) recordMap.get(KilkariConstants.DOB);
+
+            //changes made to remove special character form the listofids
+            ArrayList<String > listOfIds=new ArrayList<>();
+            listOfIds.add(KilkariConstants.BENEFICIARY_ID);
+            MctsBeneficiaryUtils.idCleanup(listOfIds,recordMap);
+
             // add child to the record
             child = mctsBeneficiaryValueProcessor.getOrCreateChildInstance(childId);
             recordMap.put(KilkariConstants.MCTS_CHILD, child);


### PR DESCRIPTION
**Issue1:**
The existing code allow line break(\n,\t,\r, white space) in the list of ids
Eg:Import record 1 with above special char then import update for same record but this time id doesn't contain special char, In this scenario system treating this id as new Id but both ids are same in the term of numerical digits.

   **After fix expected behavior:** 
   This fix will remove new Line('\n'), white space(' '), tab('\t'), '\r' form the give ids (table) before processing to DB,
   Eg: if we import record with id="12 24\t5\n\t"
   then system will save the record with id=12245
**Issue2**
creating a rch mother record with rch id r1 and mcts id=null
update the mother record with rch id r1 and mcts id m1

  Expected result=> should update the mcts id in mother record
Actual Result=> Reject the mother record with data integrity error