### PR TITLE
Bug fix : Registration date 'null' as string

### DIFF
--- a/rejection-handler/src/main/java/org/motechproject/nms/rejectionhandler/service/impl/ChildRejectionServiceImpl.java
+++ b/rejection-handler/src/main/java/org/motechproject/nms/rejectionhandler/service/impl/ChildRejectionServiceImpl.java
@@ -571,7 +571,12 @@ public class ChildRejectionServiceImpl implements ChildRejectionService {
         stringBuilder.append(child.getPhcId() + ", ");
         stringBuilder.append(QUOTATION + child.getPhcName() + QUOTATION_COMMA);
         stringBuilder.append(QUOTATION + child.getBirthDate() + QUOTATION_COMMA);
-        stringBuilder.append(QUOTATION + child.getRegistrationDate() + QUOTATION_COMMA);
+        if(child.getRegistrationDate() == null){
+            stringBuilder.append(child.getRegistrationDate() + " , ");
+        }
+        else{
+            stringBuilder.append(QUOTATION + child.getRegistrationDate() + QUOTATION_COMMA);
+        }
         stringBuilder.append(QUOTATION + child.getRegistrationNo() + QUOTATION_COMMA);
         stringBuilder.append(child.getEntryType() + ", ");
         stringBuilder.append(QUOTATION + child.getIdNo() + QUOTATION_COMMA);

--- a/rejection-handler/src/main/java/org/motechproject/nms/rejectionhandler/service/impl/MotherRejectionServiceImpl.java
+++ b/rejection-handler/src/main/java/org/motechproject/nms/rejectionhandler/service/impl/MotherRejectionServiceImpl.java
@@ -577,7 +577,12 @@ public class MotherRejectionServiceImpl implements MotherRejectionService {
         stringBuilder.append(mother.getCaseNo() + ", ");
         stringBuilder.append(QUOTATION + StringEscapeUtils.escapeSql(mother.getName()) + QUOTATION_COMMA);
         stringBuilder.append(QUOTATION + mother.getMobileNo() + QUOTATION_COMMA);
-        stringBuilder.append(QUOTATION + mother.getRegistrationDate() + QUOTATION_COMMA);
+        if(mother.getRegistrationDate() == null){
+            stringBuilder.append(mother.getRegistrationDate() + " , ");
+        }
+        else{
+            stringBuilder.append(QUOTATION + mother.getRegistrationDate() + QUOTATION_COMMA);
+        }
         stringBuilder.append(QUOTATION + mother.getLmpDate() + QUOTATION_COMMA);
         stringBuilder.append(QUOTATION + mother.getBirthDate() + QUOTATION_COMMA);
         stringBuilder.append(QUOTATION + mother.getAbortionType() + QUOTATION_COMMA);


### PR DESCRIPTION
If registrationdate date tag is missing from xml for mother and child, the values recorded as 'null' as string, which causing issue in ETL, resolved issue, now for above scenario values are recorded as NULL 