### PR TITLE
Rejected record updating mcts

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -275,12 +275,6 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
                 //validate if an ACTIVE child is already present for the mother. If yes, ignore the update
                 if (childAlreadyPresent(beneficiaryId, importOrigin)) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
-                    if (mother.getLastMenstrualPeriod() == null) {
-                        mother.setName(name);
-                        mother.setDateOfBirth(motherDOB);
-                        mother.setUpdatedDateNic(lastUpdatedDateNic);
-                        //mctsMotherDataService.update(mother);
-                    }
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.ACTIVE_CHILD_PRESENT, false);
                 }
                 subscription = subscriberService.updateMotherSubscriber(msisdn, mother, lmp, record, action,name,motherDOB,lastUpdatedDateNic);
@@ -292,12 +286,6 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
 
                 if (childAlreadyPresent(beneficiaryId, importOrigin)) {
                     LOGGER.debug("MotherImportRejection::importMotherRecord End synchronized block " + beneficiaryId);
-                    if (mother.getLastMenstrualPeriod() == null) {
-                        mother.setName(name);
-                        mother.setDateOfBirth(motherDOB);
-                        mother.setUpdatedDateNic(lastUpdatedDateNic);
-                        //mctsMotherDataService.update(mother);
-                    }
                     return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.ACTIVE_CHILD_PRESENT, false);
                 }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/MctsBeneficiaryImportServiceImpl.java
@@ -231,7 +231,7 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
         }
 
         //validate if it's an updated record compared to one from database
-        if (mother.getUpdatedDateNic() != null && (lastUpdatedDateNic == null || mother.getUpdatedDateNic().isAfter(lastUpdatedDateNic))) {
+        if (mother.getUpdatedDateNic() != null && (lastUpdatedDateNic == null || mother.getUpdatedDateNic().isAfter(lastUpdatedDateNic) || lastUpdatedDateNic.isAfter(LocalDate.now()))) {
            return createUpdateMotherRejections(flagForMcts, record, action, RejectionReasons.UPDATED_RECORD_ALREADY_EXISTS, false);
         }
         // Check if existing subscription needs to be deactivated
@@ -496,7 +496,7 @@ public class MctsBeneficiaryImportServiceImpl implements MctsBeneficiaryImportSe
         //validate if it's an updated record compared to one from database
         LOGGER.debug("child.getUpdatedDateNic() : {}", child.getUpdatedDateNic());
         LOGGER.debug("lastUpdateDateNic: {}", lastUpdateDateNic);
-        if (child.getUpdatedDateNic() != null && (lastUpdateDateNic == null || child.getUpdatedDateNic().isAfter(lastUpdateDateNic))) {
+        if (child.getUpdatedDateNic() != null && (lastUpdateDateNic == null || child.getUpdatedDateNic().isAfter(lastUpdateDateNic) || lastUpdateDateNic.isAfter(LocalDate.now()))) {
             return createUpdateChildRejections(flagForMcts, record, action, RejectionReasons.UPDATED_RECORD_ALREADY_EXISTS, false);
         }
 

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -601,6 +601,14 @@ public class SubscriberServiceImpl implements SubscriberService {
             return childRejectionRch(convertMapToRchChild(record), false, RejectionReasons.MOBILE_NUMBER_ALREADY_SUBSCRIBED.toString(), action);
         }
 
+        if(subscriberByRchId==null && childUpdate.getMother() != null && childUpdate.getMother().getId() != null &&  getSubscriberListByMother(childUpdate.getMother().getId()) != null){
+            Subscriber motherSubscriberByRchId = getSubscriberListByMother(childUpdate.getMother().getId());
+            Subscription subscription = subscriptionService.getActiveSubscription(motherSubscriberByRchId, pack.getType());
+            if(motherSubscriberByRchId.getChild()!=null && motherSubscriberByRchId.getChild().getRchId()!=null  && !Objects.equals(motherSubscriberByRchId.getChild().getRchId(), childUpdate.getRchId()) && subscription!=null){
+                return childRejectionRch(convertMapToRchChild(record), false, RejectionReasons.ALREADY_SUBSCRIBED.toString(), action);
+            }
+        }
+
         if (subscriberByRchId != null) { //subscriber exists with the provided RCH id
             if (subscribersByMsisdn.isEmpty()) { //no subscriber with provided msisdn
                 //subscriber's number has changed
@@ -668,6 +676,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherSubscriberByRchId.setDateOfBirth(dob);
                 motherSubscriberByRchId.setChild(childUpdate);
                 motherSubscriberByRchId.setModificationDate(DateTime.now());
+                motherSubscriberByRchId.setCallingNumber(msisdn);
                 finalSubscription = updateOrCreateSubscription(motherSubscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             }
             else {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -661,10 +661,13 @@ public class SubscriberServiceImpl implements SubscriberService {
 
             if(childUpdate.getMother() != null && childUpdate.getMother().getId() != null &&  getSubscriberListByMother(childUpdate.getMother().getId()) != null){
                 Subscriber motherSubscriberByRchId = getSubscriberListByMother(childUpdate.getMother().getId());
+                Subscription subscription = subscriptionService.getActiveSubscription(motherSubscriberByRchId, pack.getType());
+                if (subscription!=null)
+                    // Mother is already having another active child registered
+                    return childRejectionRch(convertMapToRchChild(record), false, RejectionReasons.ALREADY_SUBSCRIBED.toString(), action);
                 motherSubscriberByRchId.setDateOfBirth(dob);
                 motherSubscriberByRchId.setChild(childUpdate);
                 motherSubscriberByRchId.setModificationDate(DateTime.now());
-                Subscription subscription = subscriptionService.getActiveSubscription(motherSubscriberByRchId, pack.getType());
                 finalSubscription = updateOrCreateSubscription(motherSubscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             }
             else {


### PR DESCRIPTION
Contain 3 bugs fixes. Rejected record should not update mcts table. Active child should not get replaced with another child. Future exec date should get rejected