### PR TITLE
Any update regarding subscriber should delete record from retry table

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriptionService.java
@@ -104,6 +104,8 @@ public interface SubscriptionService {
      */
     void deactivateSubscription(Subscription subscription, DeactivationReason reason);
 
+    void deleteCallRetry(String subscriptionId);
+
     void deleteBlockedMsisdn(Long motherId, Long oldCallingNumber, Long newCallingNumber);
 
     /**

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriberServiceImpl.java
@@ -391,6 +391,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                 motherUpdate.setRegistrationDate(motherRegistrationDate);
                 subscriberByRchId.setCaseNo(caseNo);
                 motherUpdate.setMaxCaseNo(caseNo);
+                if(subscription != null){subscriptionService.deleteCallRetry(subscription.getSubscriptionId());}
                 return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {  // we have a subscriber by phone# and also one with the RCH id
                 if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn,msisdn, SubscriptionPackType.PREGNANCY, motherUpdate.getRchId(), null)) {
@@ -401,6 +402,9 @@ public class SubscriberServiceImpl implements SubscriberService {
                     if ((subscriberByRchId.getId().equals(subscriber.getId())) && (subscriberByRchId.getCaseNo() == null || subscriberByRchId.getCaseNo() <= caseNo)) {
                         Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                         motherUpdate.setMaxCaseNo(caseNo);
+                        if ((subscription != null) && !((subscriberByRchId.getLastMenstrualPeriod().getDayOfYear() == lmp.getDayOfYear()) && (subscriberByRchId.getLastMenstrualPeriod().getYear() == lmp.getYear()))) {
+                            subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                        }
                         subscriberByRchId.setLastMenstrualPeriod(lmp);
 
                         motherUpdate.setName(name);
@@ -428,6 +432,7 @@ public class SubscriberServiceImpl implements SubscriberService {
                     subscriberByRchId.setCaseNo(caseNo);
                     motherUpdate.setMaxCaseNo(caseNo);
                     subscriberByRchId.setModificationDate(DateTime.now());
+                    if(subscription != null){subscriptionService.deleteCallRetry(subscription.getSubscriptionId());}
 
                     return updateOrCreateSubscription(subscriberByRchId, subscription, lmp, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             }
@@ -621,16 +626,21 @@ public class SubscriberServiceImpl implements SubscriberService {
                 Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                 subscriberByRchId.setDateOfBirth(dob);
                 subscriberByRchId.setModificationDate(DateTime.now());
+                // Delete that record from retry table as beneficiary gets their mobile number update
+                if(subscription != null){subscriptionService.deleteCallRetry(subscription.getSubscriptionId());}
                 finalSubscription = updateOrCreateSubscription(subscriberByRchId, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
             } else {
                 //subscriber found with provided msisdn
                 if(childUpdate.getMother()!=null){
                     Subscriber subscriber = getSubscriberListByMother(childUpdate.getMother().getId());
+                    Subscription subscription = subscriptionService.getActiveSubscription(subscriber, pack.getType());
+                    if ((!Objects.equals(subscriber.getCallingNumber(), msisdn) || subscriber.getDateOfBirth().getDayOfYear() != dob.getDayOfYear()) && subscription!=null){
+                        subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                    }
                     subscriber.setCallingNumber(msisdn);
                     subscriber.setDateOfBirth(dob);
                     subscriber.setChild(childUpdate);
                     subscriber.setModificationDate(DateTime.now());
-                    Subscription subscription = subscriptionService.getActiveSubscription(subscriber, pack.getType());
                     finalSubscription = updateOrCreateSubscription(subscriber, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                 }
                 else {
@@ -640,6 +650,9 @@ public class SubscriberServiceImpl implements SubscriberService {
                             Subscription subscription = subscriptionService.getActiveSubscription(subscriberByRchId, pack.getType());
                             if (subscriberByRchId.getMother() == null) {
                                 subscriberByRchId.setMother(childUpdate.getMother());
+                            }
+                            if ((subscriberByRchId.getDateOfBirth().getDayOfYear() != dob.getDayOfYear()) && subscription!=null){
+                                subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
                             }
                             subscriberByRchId.setDateOfBirth(dob);
                             subscriberByRchId.setModificationDate(DateTime.now());
@@ -706,10 +719,13 @@ public class SubscriberServiceImpl implements SubscriberService {
                         //update subscriber with child
                         if (childUpdate.getMother().getRchId() != null && subscribersByMsisdn.get(0).getMother().getRchId() != null && childUpdate.getMother().getRchId().equals(subscribersByMsisdn.get(0).getMother().getRchId())) {
                             Subscriber subscriber = subscribersByMsisdn.get(0);
+                            Subscription subscription = subscriptionService.getActiveSubscription(subscriber, pack.getType());
+                            if (subscription != null && !((subscriber.getDateOfBirth().getDayOfYear() == dob.getDayOfYear()) && (subscriber.getDateOfBirth().getYear() == dob.getYear()))){
+                                subscriptionService.deleteCallRetry(subscription.getSubscriptionId());
+                            }
                             subscriber.setDateOfBirth(dob);
                             subscriber.setChild(childUpdate);
                             subscriber.setModificationDate(DateTime.now());
-                            Subscription subscription = subscriptionService.getActiveSubscription(subscriber, pack.getType());
                             finalSubscription = updateOrCreateSubscription(subscriber, subscription, dob, pack, language, circle, SubscriptionOrigin.RCH_IMPORT, false);
                         } else {
                             if (subscriptionService.activeSubscriptionByMsisdnRch(subscribersByMsisdn, msisdn, SubscriptionPackType.CHILD, motherRchId, childUpdate.getRchId())) {

--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/impl/SubscriptionServiceImpl.java
@@ -933,7 +933,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
      * Delete the CallRetry record corresponding to the given subscription     *
      * @param subscriptionId subscription to delete the CallRetry record fors
      */
-    private void deleteCallRetry(String subscriptionId) {
+    @Override
+    public void deleteCallRetry(String subscriptionId) {
         CallRetry callRetry = callRetryDataService.findBySubscriptionId(subscriptionId);
         if (callRetry != null) {
             callRetryDataService.delete(callRetry);


### PR DESCRIPTION
LMP/ DOB and mobile number update should delete the record from retry table. It should prevent it from having a new record in case update came first before CSR and CDR