### PR TITLE
Manual deactivation api

### DIFF
--- a/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
+++ b/kilkari/src/main/java/org/motechproject/nms/kilkari/service/SubscriberService.java
@@ -14,6 +14,7 @@ import org.motechproject.nms.rejectionhandler.domain.ChildImportRejection;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Service interface for managing Kilkari subscribers
@@ -116,4 +117,6 @@ public interface SubscriberService {
      * @return new or updated subscription, null if create/update fails
      */
     ChildImportRejection updateRchChildSubscriber(Long msisdn, MctsChild child, DateTime dob, Map<String, Object> record, String action);
+
+    void processChunkOfDeactivation(List<String[]> chunk, AtomicInteger successCount, List<String> failureMessages);
 }


### PR DESCRIPTION
Deactivation api for manual deactivation and self-deactivation get separated, to enhance the performance of Manual deactivation.Near about 6-12 lakhs of records are getting deactivated weekly after increasing base capacity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added bulk deactivation functionality for subscriptions
  - Introduced a new endpoint for processing bulk deactivation requests via file upload

- **Improvements**
  - Enhanced error handling for bulk deactivation process
  - Implemented parallel processing of deactivation records
  - Added validation for input records and MSISDNs

- **Performance**
  - Implemented concurrent processing of subscription deactivations
  - Added transactional support for deactivation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->